### PR TITLE
[fix] #4 whitelist 형식 수정

### DIFF
--- a/src/main/java/nova/backend/global/auth/SecurityConfig.java
+++ b/src/main/java/nova/backend/global/auth/SecurityConfig.java
@@ -24,14 +24,16 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
 
     // 토큰 없이 접근 가능한 URL
-    private static final String[] whiteList = {"/",
-            "token/**",
+    private static final String[] whiteList = {
+            "/",
+            "/token/**",
 
             /* swagger */
-            "swagger/**",
-            "swagger-ui/**",
-            "v3/api-docs/**",
+            "/swagger/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
     };
+
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #4 
 
## 🌱 작업 사항
배포 주소로 swagger 접속시 502 에러 해결하기

## 🌱 참고 사항
👉 "swagger-ui/**" → "/swagger-ui/**" 처럼 고쳐야 Spring Security가 경로를 정확히 매칭해줄 수 있음
Spring Security 6부터는 슬래시 없는 경로는 매칭이 안 되거나 경고만 나오고 무시될 수 있음
따라서 SecurityConfig whitelist를 수정함