### PR TITLE
[fix] UserService에서 read-only 삭제

### DIFF
--- a/src/main/java/nova/backend/domain/user/service/UserService.java
+++ b/src/main/java/nova/backend/domain/user/service/UserService.java
@@ -28,7 +28,6 @@ public class UserService {
 
         if (existedUser == null) {
             String qrCode = QrCodeGenerator.generate();
-            System.out.println("🔍 Generated QR Code = " + qrCode); // TODO: 삭제하기
 
             User newUser = User.builder()
                     .socialId(socialId)
@@ -39,10 +38,7 @@ public class UserService {
                     .qrCodeValue(qrCode)
                     .build();
 
-            User savedUser = userRepository.save(newUser);
-            System.out.println("✅ User saved: " + savedUser.getUserId()); // TODO: 삭제하기
-
-            return savedUser;
+            return userRepository.save(newUser);
 
         }
 

--- a/src/main/java/nova/backend/domain/user/service/UserService.java
+++ b/src/main/java/nova/backend/domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #5
 
## 🌱 작업 사항
QrCode 로그 추가하여 확인 결과, 잘 생성되고 insert까지 잘 되지만 실제 DB에 반영 안 됨.
UserService에 붙어있던 read-only를 삭제함. 그리고 로그 삭제. 

## 🌱 참고 사항
```
Hibernate:
    select
        u1_0.user_id,
        u1_0.cafe_id,
        u1_0.created_at,
        u1_0.email,
        u1_0.is_deleted,
        u1_0.name,
        u1_0.phone,
        u1_0.profile_image_url,
        u1_0.qr_code_value,
        u1_0.role,
        u1_0.social_id,
        u1_0.social_type,
        u1_0.updated_at
    from
        user u1_0
    where
        u1_0.social_type=?
        and u1_0.social_id=?
🔍 Generated QR Code = ODU1ZDk5MDMtODY0MC00ZTU5LWE1OTEtOGM2NTI3YmFiNWVh
Hibernate:
    insert
    into
        user
        (cafe_id, created_at, email, is_deleted, name, phone, profile_image_url, qr_code_value, role, social_id, social_type, updated_at)
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
✅ User saved: 5
```
