### PR TITLE
[fix] #46 적립 권한 fix (ROLE_ 추가)

### DIFF
--- a/src/main/java/nova/backend/global/auth/SecurityConfig.java
+++ b/src/main/java/nova/backend/global/auth/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
-    private final CustomUserDetailsService customUserDetailsService; // ✅ 추가
+    private final CustomUserDetailsService customUserDetailsService;
 
     private static final String[] whiteList = {
             "/", "/swagger/**", "/swagger-ui/**", "/v3/api-docs/**",
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(config -> config.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/cafe/stamps/**").hasAnyAuthority("OWNER", "STAFF")
+                        .requestMatchers("/api/cafe/stamps/**").hasAnyAuthority("ROLE_OWNER", "ROLE_STAFF")
                         .requestMatchers(whiteList).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #46 
 
## 🌱 작업 사항
ROLE_을 붙여 테스트 완료

## 🌱 참고 사항
지금 상황을 보면 로그상으로는 JwtAuthenticationFilter가 정상적으로 작동하여 ROLE_OWNER 권한을 부여하고 있음에도 불구하고, 401 Unauthorized가 발생하고 있어요.

🔍 의심 포인트
SecurityConfig에서 .requestMatchers("/api/cafe/stamps/**").hasAnyAuthority("OWNER", "STAFF")를 사용했는데, 
이건 SimpleGrantedAuthority로 등록된 이름과 정확히 일치해야 한다.

✅ 문제의 원인
Spring Security에서 `hasAuthority("OWNER")`라고 쓰면 내부적으로는 다음과 같은 객체를 찾는다.
`new SimpleGrantedAuthority("OWNER")`
하지만 지금 `CustomUserDetails`에서는 이렇게 권한을 등록하고 있다:
`return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));`
즉, 실제 등록된 권한은 `ROLE_OWNER`인데, `.hasAuthority("OWNER")`로 검사하고 있으니 매칭되지 않아서 401이 발생했다.
