### PR TITLE
[feat/docs] JWT에서 cafeId 추출하도록 변경하고, 권한 정리, API 문서 깔끔하게 정리하기

### DIFF
--- a/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nova.backend.domain.cafe.schema.CafeListSuccessResponse;
 import nova.backend.global.common.SuccessResponse;
@@ -18,14 +19,14 @@ public interface CafeApi {
             "\n 2. 요일별 isOpen: 카페에서 설정한 요일별 오픈 여부입니다." +
             "\n * Special Days: 카페에서 지정한 임시 휴일/공휴일입니다. specialDays의 isOpen값이 일반 운영시간보다 우선순위를 가집니다." +
             "\n * Special Days를 월별로만 가져오는 추가 처리가 필요할 것 같습니다. 현재는 전체 specialDay를 가져옵니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "카페 목록 조회 성공",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = CafeListSuccessResponse.class)
-            )
-    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카페 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CafeListSuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class)))
+    })
     @GetMapping
     ResponseEntity<SuccessResponse<?>> getCafeList();
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
@@ -1,6 +1,7 @@
 package nova.backend.domain.cafe.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,25 +9,38 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nova.backend.domain.cafe.schema.CafeListSuccessResponse;
 import nova.backend.global.common.SuccessResponse;
+import nova.backend.global.error.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "카페 API", description = "카페 목록 관련 API")
+@Tag(name = "2. 유저(USER) 카페", description = "카페 목록 관련 API")
 public interface CafeApi {
 
-    @Operation(summary = "카페 목록 조회", description = "모든 카페의 정보를 조회합니다. isOpen의 종류가 2개 있습니다. " +
-            "\n 1. 전체 isOpen: 카페 운영시간(일반 운영시간, 임시 운영시간) & 현재 날짜/시간에 따라 전체 isOpen으로 현재 오픈 여부를 판단합니다. " +
-            "\n 2. 요일별 isOpen: 카페에서 설정한 요일별 오픈 여부입니다." +
-            "\n * Special Days: 카페에서 지정한 임시 휴일/공휴일입니다. specialDays의 isOpen값이 일반 운영시간보다 우선순위를 가집니다." +
-            "\n * Special Days를 월별로만 가져오는 추가 처리가 필요할 것 같습니다. 현재는 전체 specialDay를 가져옵니다.")
+    @Operation(
+            summary = "카페 목록 조회",
+            description = "카페 목록을 조회합니다.\n\n" +
+                    "✅ 쿼리 파라미터 `approved`가 true일 경우, **심사에 승인된 카페**만 반환됩니다. -> 일반 사용자용!\n" +
+                    "✅ `approved`가 없거나 false일 경우, **전체 카페**가 반환됩니다. -> 관리자용!\n\n" +
+                    "추가 설명:\n" +
+                    "1. 전체 isOpen: 카페 운영시간(일반 운영시간, 임시 운영시간) & 현재 날짜/시간에 따라 전체 오픈 여부 판단\n" +
+                    "2. 요일별 isOpen: 카페가 설정한 요일별 오픈 여부\n" +
+                    "* Special Days: 카페 지정 임시 휴일/공휴일 (specialDays의 isOpen이 일반 운영시간보다 우선)\n" +
+                    "* 현재 specialDays는 전체 조회 (월별 필터링은 추후 개선 예정)",
+            parameters = {
+                    @Parameter(name = "approved", description = "승인된 카페만 조회 여부 (true: 승인된 카페만, false/없음: 전체 카페)", example = "true")
+            }
+    )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "카페 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = CafeListSuccessResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 에러",
-                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
-    ResponseEntity<SuccessResponse<?>> getCafeList();
+    ResponseEntity<SuccessResponse<?>> getCafeList(
+            @RequestParam(required = false) Boolean approved
+    );
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeController.java
@@ -21,17 +21,17 @@ public class CafeController implements CafeApi {
     private final CafeService cafeService;
 
     @GetMapping
-    public ResponseEntity<SuccessResponse<?>> getCafeList() {
-        List<CafeListResponseDTO> response = cafeService.getAllCafes();
+    public ResponseEntity<SuccessResponse<?>> getCafeList(
+            @RequestParam(required = false) Boolean approved
+    ) {
+        List<CafeListResponseDTO> response;
+        if (approved != null && approved) {
+            response = cafeService.getApprovedCafes();
+        } else {
+            response = cafeService.getAllCafes();
+        }
         return SuccessResponse.ok(response);
     }
-
-    @GetMapping("/approved")
-    public ResponseEntity<SuccessResponse<?>> getApprovedCafeList() {
-        List<CafeListResponseDTO> response = cafeService.getApprovedCafes();
-        return SuccessResponse.ok(response);
-    }
-
 
 }
 

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionApi.java
@@ -1,0 +1,46 @@
+package nova.backend.domain.cafe.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import nova.backend.global.auth.CustomUserDetails;
+import nova.backend.global.common.SuccessResponse;
+import nova.backend.global.error.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "카페 선택 API", description = "사장/직원이 현재 선택된 카페를 설정하는 API")
+public interface CafeSelectionApi {
+
+    @Operation(
+            summary = "현재 카페 선택",
+            description = "사장 또는 직원이 로그인 후, 소속된 카페 중 하나를 선택하여 '현재 카페'로 설정합니다. " +
+                    "cafeId가 필요한 곳에(ex. 스탬프 적립 등) 지정하지 않고 JWT에 담아서 자동 추출합니다. " +
+                    "현재 카페가 설정되지 않은 상태로 작업할 경우 에러를 반환합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카페 선택 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (예: 토큰 문제)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 부족 (해당 카페에 접근 권한 없음)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "카페를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{cafeId}/select")
+    ResponseEntity<SuccessResponse<?>> selectCafe(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "선택할 카페의 ID", example = "1") @PathVariable Long cafeId
+    );
+}
+
+

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionApi.java
@@ -15,32 +15,35 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 
-@Tag(name = "카페 선택 API", description = "사장/직원이 현재 선택된 카페를 설정하는 API")
+@Tag(name = "3. 카페(OWNER/STAFF) 카페 선택 API", description = "로그인 후 현재 선택할 카페를 설정하는 API")
 public interface CafeSelectionApi {
 
     @Operation(
-            summary = "현재 카페 선택",
-            description = "사장 또는 직원이 로그인 후, 소속된 카페 중 하나를 선택하여 '현재 카페'로 설정합니다. " +
-                    "cafeId가 필요한 곳에(ex. 스탬프 적립 등) 지정하지 않고 JWT에 담아서 자동 추출합니다. " +
-                    "현재 카페가 설정되지 않은 상태로 작업할 경우 에러를 반환합니다.",
+            summary = "카페 선택 (스태프/사장)",
+            description = "스태프 또는 사장이 자신이 소속된 카페 중 하나를 선택하여 '현재 선택된 카페'로 설정합니다.\n" +
+                    "선택된 카페는 Redis에 저장되며, 추후 JWT 또는 인증객체에서 자동으로 사용됩니다.\n\n" +
+                    "✅ 선택할 수 있는 카페는 자신이 staff 또는 owner로 소속된 카페만 가능합니다.\n" +
+                    "✅ 잘못된 카페 ID 또는 권한이 없는 카페를 선택 시 ACCESS_DENIED 에러가 발생합니다.",
             security = @SecurityRequirement(name = "token")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "카페 선택 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (예: 토큰 문제)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "권한 부족 (해당 카페에 접근 권한 없음)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "카페를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (해당 카페에 staff/owner로 등록 안됨)",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "카페 존재하지 않음",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class)))
     })
-    @PostMapping("/{cafeId}/select")
+    @PutMapping("/{cafeId}/selected")
     ResponseEntity<SuccessResponse<?>> selectCafe(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "선택할 카페의 ID", example = "1") @PathVariable Long cafeId
+            @Parameter(description = "선택할 카페 ID", example = "1") @PathVariable Long cafeId
     );
 }
+
 
 

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/cafes")
-public class CafeSelectionController {
+public class CafeSelectionController implements CafeSelectionApi{
     private final CafeSelectionService cafeSelectionService;
 
     @PostMapping("/{cafeId}/select")

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeSelectionController.java
@@ -6,24 +6,21 @@ import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/cafes")
+@RequestMapping("/api/staff/cafes")
 public class CafeSelectionController implements CafeSelectionApi{
     private final CafeSelectionService cafeSelectionService;
 
-    @PostMapping("/{cafeId}/select")
+    @PutMapping("/{cafeId}/selected")
     public ResponseEntity<SuccessResponse<?>> selectCafe(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long cafeId
     ) {
         cafeSelectionService.selectCafe(userDetails.getUserId(), cafeId);
-        return SuccessResponse.ok("매장 선택 완료");
+        return SuccessResponse.ok("선택된 카페 설정 완료");
     }
 
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@Tag(name = "카페(OWNER) API", description = "카페 등록 API")
+@Tag(name = "4. 사장(OWNER) API", description = "카페 등록/관리 API")
 public interface OwnerCafeApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nova.backend.domain.cafe.dto.request.CafeRegistrationRequestDTO;
@@ -28,15 +29,21 @@ public interface OwnerCafeApi {
             required = true,
             content = @Content(schema = @Schema(implementation = CafeRegistrationRequestDTO.class))
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "카페 등록 성공",
-            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
-    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카페 등록 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (예: 토큰 문제)",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 부족 (Owner 권한 아님)",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 등록된 카페",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러",
+                    content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class)))
+    })
     @PostMapping("/register")
     ResponseEntity<SuccessResponse<?>> registerCafe(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @org.springframework.web.bind.annotation.RequestBody CafeRegistrationRequestDTO request
     );
-
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/cafe")
+@RequestMapping("/api/owner/cafes")
 public class OwnerCafeController implements OwnerCafeApi{
 
     private final CafeService cafeService;

--- a/src/main/java/nova/backend/domain/stamp/controller/StaffStampApi.java
+++ b/src/main/java/nova/backend/domain/stamp/controller/StaffStampApi.java
@@ -13,18 +13,25 @@ import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "카페(OWNER/STAFF)용 스탬프 API", description = "사장/직원용 스탬프 적립 및 조회 API")
+@Tag(name = "3. 카페(OWNER/STAFF) 스탬프", description = "스탬프 적립 및 조회 API (카페 선택 이후 사용 가능)")
 public interface StaffStampApi {
 
     @Operation(
             summary = "스탬프 적립",
-            description = "카페 사장/직원이 Profile QR 코드를 기반(UUID) 으로 유저에게 스탬프를 적립합니다.",
+            description = """
+                    카페 사장/직원이 Profile QR 코드(UUID)를 사용하여 해당 유저에게 스탬프를 적립합니다.
+                    
+                    ✅ cafeId는 SecurityContextHolder에 저장된 selectedCafeId로 처리됩니다.
+                    ✅ staff/owner 권한이 없거나 카페 선택 안했으면 403 또는 404 예외 발생
+                    """,
             security = @SecurityRequirement(name = "token")
     )
-    @RequestBody(
-            description = "적립 대상 회원의 QR 코드, 카페 ID, 적립 개수를 포함한 요청 DTO",
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "적립 대상 회원의 QR 코드(UUID)와 적립 개수를 포함한 요청 DTO",
             required = true,
             content = @Content(schema = @Schema(implementation = StampAccumulateRequestDTO.class))
     )
@@ -33,10 +40,57 @@ public interface StaffStampApi {
             description = "스탬프 적립 성공",
             content = @Content(schema = @Schema(implementation = SuccessResponse.class))
     )
+    @ApiResponse(
+            responseCode = "400",
+            description = "유효하지 않은 요청 (예: 카페 미선택)",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = "권한 부족 (해당 카페 staff/owner 아님)",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "대상 유저 또는 카페를 찾을 수 없음 (ENTITY_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))
+    )
     @PostMapping
     ResponseEntity<SuccessResponse<?>> accumulateStamp(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @org.springframework.web.bind.annotation.RequestBody StampAccumulateRequestDTO request
     );
 
+
+    @Operation(
+            summary = "적립 직후 유저 스탬프 현황 조회",
+            description = """
+                    카페 사장/직원이 유저의 QR 코드(UUID)를 사용하여 해당 유저의 스탬프 적립 현황을 조회합니다.
+                    
+                    ✅ 카페 staff/owner 권한이 필요합니다.
+                    ✅ cafeId는 SecurityContextHolder에 저장된 selectedCafeId로 처리됩니다.
+                    """,
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "스탬프 현황 조회 성공",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.common.SuccessResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = "권한 부족 (해당 카페 staff/owner 아님)",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "대상 유저를 찾을 수 없음 (ENTITY_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = nova.backend.global.error.dto.ErrorResponse.class))
+    )
+    @GetMapping
+    ResponseEntity<SuccessResponse<?>> getStampHistoryForStaffView(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "조회할 유저의 QR 코드(UUID)", required = true)
+            @RequestParam String qrCodeValue
+    );
 }

--- a/src/main/java/nova/backend/domain/stamp/controller/StaffStampController.java
+++ b/src/main/java/nova/backend/domain/stamp/controller/StaffStampController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/cafe/stamps")
+@RequestMapping("/api/staff/stamps")
 public class StaffStampController implements StaffStampApi {
 
     private final StampService stampService;

--- a/src/main/java/nova/backend/domain/stamp/controller/StampApi.java
+++ b/src/main/java/nova/backend/domain/stamp/controller/StampApi.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Tag(name = "일반회원(USER)용 스탬프 API", description = "스탬프 조회 API")
+@Tag(name = "2. 유저(USER) 스탬프", description = "스탬프 조회 API")
 public interface StampApi {
 
     @Operation(summary = "나의 스탬프 적립/사용 내역 조회", description = "내 스탬프 적립 및 사용 히스토리를 조회합니다. 피그마 보고 수정이 필요합니다.", security = @SecurityRequirement(name = "token"))

--- a/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookApi.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookApi.java
@@ -17,13 +17,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 
-@Tag(name = "카페(OWNER/STAFF)용 스탬프북 API", description = "사장/직원용 리워드 사용 API")
+@Tag(name = "3. 카페(OWNER/STAFF) 스탬프북", description = "사장/직원용 리워드 사용 API (카페 선택 후 사용 가능)")
 public interface StaffStampBookApi {
 
     @Operation(
             summary = "QR 코드로 리워드 사용 처리",
-            description = "카페 사장/직원이 대상 유저의 QR 코드(UUID)를 사용하여 리워드를 사용 처리합니다.\n" +
-                    "요청 수량보다 보유 리워드가 적으면 400 예외 발생.",
+            description = """
+                    카페 사장/직원이 대상 유저의 QR 코드(UUID)를 입력받아 리워드 스탬프 사용 처리를 합니다.
+                    
+                    ✅ 요청 수량보다 사용 가능한 리워드 수량이 부족하면 `NOT_ENOUGH_REWARDS` 예외 (400) 발생
+                    ✅ cafeId는 SecurityContextHolder 내 userDetails.selectedCafeId로 처리되며, cafeSelection을 선행해야 합니다.
+                    ✅ user가 해당 카페의 staff/owner가 아닐 경우 403 예외 발생
+                    """,
             security = @SecurityRequirement(name = "token")
     )
     @ApiResponses({
@@ -31,16 +36,21 @@ public interface StaffStampBookApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
             @ApiResponse(responseCode = "400", description = "사용 가능한 리워드 부족 (NOT_ENOUGH_REWARDS)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
+            @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 만료 또는 미인증)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "권한 부족",
+            @ApiResponse(responseCode = "403", description = "권한 부족 (해당 카페 staff/owner 아님)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 또는 카페를 찾을 수 없음, cafeSelection을 했는지 먼저 확인해주세요.",
+            @ApiResponse(responseCode = "404", description = "대상 사용자 또는 카페를 찾을 수 없음 (ENTITY_NOT_FOUND)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PatchMapping("/rewards/use-by-qr")
+    @PatchMapping("/rewards")
     ResponseEntity<SuccessResponse<?>> useRewardsByQrCodeForCafe(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody UseRewardsRequestDTO request
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "리워드 사용 요청 DTO (qrCodeValue, count 포함)",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = UseRewardsRequestDTO.class))
+            )
+            @org.springframework.web.bind.annotation.RequestBody UseRewardsRequestDTO request
     );
 }

--- a/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookController.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookController.java
@@ -13,12 +13,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/cafe/stampbooks")
+@RequestMapping("/api/staff/stampbooks")
 public class StaffStampBookController implements StaffStampBookApi {
 
     private final StampBookService stampBookService;
 
-    @PatchMapping("/rewards/use-by-qr")
+    @PatchMapping("/rewards")
     public ResponseEntity<SuccessResponse<?>> useRewardsByQrCodeForCafe(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UseRewardsRequestDTO request

--- a/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookController.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StaffStampBookController.java
@@ -5,6 +5,8 @@ import nova.backend.domain.stampBook.dto.request.UseRewardsRequestDTO;
 import nova.backend.domain.stampBook.service.StampBookService;
 import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +24,7 @@ public class StaffStampBookController implements StaffStampBookApi {
             @RequestBody UseRewardsRequestDTO request
     ) {
         int updatedCount = stampBookService.useRewardsByQrCodeForCafe(
-                userDetails.getUserId(), request.cafeId(), request.qrCodeValue(), request.count()
+                userDetails.getUserId(), userDetails.getSelectedCafeId(), request.qrCodeValue(), request.count()
         );
         return SuccessResponse.ok("사용 처리된 리워드 수: " + updatedCount);
     }

--- a/src/main/java/nova/backend/domain/stampBook/controller/StampBookApi.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StampBookApi.java
@@ -16,11 +16,9 @@ import nova.backend.global.common.SuccessResponse;
 import nova.backend.global.error.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "스탬프북 API", description = "스탬프북 관련 API, 스탬프는 단일 스탬프지만 스탬프북은 한 장을 관리합니다.")
+@Tag(name = "2. 유저(USER) 스탬프북", description = "스탬프북 관련 API, 스탬프는 단일 스탬프지만 스탬프북은 한 장을 관리합니다.")
 public interface StampBookApi {
 
     @Operation(
@@ -61,5 +59,81 @@ public interface StampBookApi {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody StampBookCreateRequestDTO request
     );
-}
 
+    @Operation(
+            summary = "스탬프북 리워드 전환",
+            description = "스탬프북을 리워드로 전환합니다.\n전환 조건이 충족되지 않으면 예외 발생.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리워드 전환 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 미완료 스탬프북)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "스탬프북을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{stampBookId}/reward")
+    ResponseEntity<SuccessResponse<?>> convertToReward(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long stampBookId
+    );
+
+    @Operation(
+            summary = "스탬프북을 메인페이지에 추가",
+            description = "선택한 스탬프북을 메인페이지에 표시되도록 추가합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메인페이지 추가 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "스탬프북을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{stampBookId}/home")
+    ResponseEntity<SuccessResponse<?>> addStampBookToHome(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long stampBookId
+    );
+
+    @Operation(
+            summary = "스탬프북을 메인페이지에서 제거",
+            description = "선택한 스탬프북을 메인페이지에서 제거합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메인페이지 제거 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "스탬프북을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/{stampBookId}/home")
+    ResponseEntity<SuccessResponse<?>> removeStampBookFromHome(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long stampBookId
+    );
+
+    @Operation(
+            summary = "메인페이지용 스탬프북 목록 조회 (inHome=true)",
+            description = "메인페이지에 표시되는 스탬프북 목록만 조회합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메인페이지 스탬프북 조회 성공",
+                    content = @Content(schema = @Schema(implementation = StampBookListSuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 부족",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/my/home")
+    ResponseEntity<SuccessResponse<?>> getMyHomeStampBooks(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/nova/backend/domain/stampBook/controller/StampBookApi.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StampBookApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import nova.backend.domain.stampBook.dto.request.StampBookCreateRequestDTO;
@@ -12,6 +13,7 @@ import nova.backend.domain.stampBook.schema.StampBookListSuccessResponse;
 import nova.backend.domain.stampBook.schema.StampBookSuccessResponse;
 import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
+import nova.backend.global.error.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,33 +23,43 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "스탬프북 API", description = "스탬프북 관련 API, 스탬프는 단일 스탬프지만 스탬프북은 한 장을 관리합니다.")
 public interface StampBookApi {
 
-    @Operation(summary = "나의 스탬프북 목록 조회 (for 메인페이지 / 스탬프북 페이지)",
-            description = "나의 스탬프북 목록을 모두 조회합니다. 현재는 리워드 전환 여부 관계없이 모두 표시하고 있습니다. 이후에는 리워드 전환된 스탬프북은 표시하지 않을 예정입니다. (구현 예정)" +
-                    "\n inHome=true이면 메인페이지에서 표시해야 합니다.",
-            security = @SecurityRequirement(name = "token"))
-    @ApiResponse(responseCode = "200", description = "스탬프북 목록 조회 성공",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = StampBookListSuccessResponse.class)
-            )
+    @Operation(
+            summary = "나의 스탬프북 목록 조회 (for 메인페이지 / 스탬프북 페이지)",
+            description = "나의 스탬프북 목록을 모두 조회합니다.\n리워드 전환 여부 관계없이 모두 표시하고 있습니다.\n(inHome=true이면 메인페이지용)",
+            security = @SecurityRequirement(name = "token")
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스탬프북 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = StampBookListSuccessResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 부족",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/my")
     ResponseEntity<SuccessResponse<?>> getMyStampBooks(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "스탬프북 다운로드(생성)",
-            description = "카페 목록에서 스탬프북 다운로드를 하면 이 API를 사용해야 합니다. 찍힌 스탬프 개수가 0인 새로운 스탬프북이 생성됩니다. 채우지 않은 스탬프북이 이미 있는데 또 다운로드 받는 경우 에러를 던집니다.",
-            security = @SecurityRequirement(name = "token"))
-    @ApiResponse(responseCode = "201", description = "스탬프북 생성 성공",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = StampBookSuccessResponse.class)
-            )
+    @Operation(
+            summary = "스탬프북 다운로드(생성)",
+            description = "카페 목록에서 스탬프북 다운로드 시 사용.\n이미 생성된 미완료 스탬프북이 있으면 409 예외 발생.",
+            security = @SecurityRequirement(name = "token")
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "스탬프북 생성 성공",
+                    content = @Content(schema = @Schema(implementation = StampBookSuccessResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 생성된 스탬프북 존재 (STAMPBOOK_ALREADY_EXISTS)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 부족",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping
     ResponseEntity<SuccessResponse<?>> createStampBook(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody StampBookCreateRequestDTO request
     );
 }
+

--- a/src/main/java/nova/backend/domain/stampBook/controller/StampBookController.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/StampBookController.java
@@ -51,7 +51,7 @@ public class StampBookController implements StampBookApi{
         return SuccessResponse.ok("리워드 전환 완료: " + reward);
     }
 
-    // 마이페이지에 스탬프북 추가
+    // 메인페이지에 스탬프북 추가
     @PostMapping("/{stampBookId}/home")
     public ResponseEntity<SuccessResponse<?>> addStampBookToHome(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -61,7 +61,7 @@ public class StampBookController implements StampBookApi{
         return SuccessResponse.ok("마이페이지에 추가되었습니다.");
     }
 
-    // 마이페이지에서 스탬프북 제거
+    // 메인페이지에서 스탬프북 제거
     @DeleteMapping("/{stampBookId}/home")
     public ResponseEntity<SuccessResponse<?>> removeStampBookFromHome(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/nova/backend/domain/stampBook/dto/request/UseRewardsRequestDTO.java
+++ b/src/main/java/nova/backend/domain/stampBook/dto/request/UseRewardsRequestDTO.java
@@ -1,7 +1,7 @@
 package nova.backend.domain.stampBook.dto.request;
 
 public record UseRewardsRequestDTO(
-        Long cafeId, // OWNER와 CAFE는 1:N 관계라서 jwt로 카페 정보를 자동으로 가져올 수 없음.
         String qrCodeValue,
         int count
 ) {}
+

--- a/src/main/java/nova/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/nova/backend/domain/user/controller/AuthApi.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "인증 API", description = "인증 관련 API")
+@Tag(name = "1. 인증", description = "인증 관련 API")
 public interface AuthApi {
 
     @Operation(summary = "임시 토큰 발급",

--- a/src/main/java/nova/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/nova/backend/domain/user/controller/UserApi.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Tag(name = "일반 회원 API", description = "일반 회원 관련 API")
+@Tag(name = "1. 유저", description = "일반 회원 관련 API")
 public interface UserApi {
 
     @Operation(

--- a/src/main/java/nova/backend/global/auth/SecurityConfig.java
+++ b/src/main/java/nova/backend/global/auth/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(config -> config.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/cafe/stamps/**").hasAnyAuthority("ROLE_OWNER", "ROLE_STAFF")
+                        .requestMatchers("/api/owner").hasAnyAuthority("ROLE_OWNER")
+                        .requestMatchers("/api/staff").hasAnyAuthority("ROLE_OWNER", "ROLE_STAFF")
                         .requestMatchers(whiteList).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #58 
 
## 🌱 작업 사항

1. cafeId를 파라미터로 받지 않고 JWT에서 추출하도록 한다.
2. 권한을 정리하여 securityConfig에 적용한다.
3. 경로명을 깔끔하게 정리한다.
4. API 문서를 정리한다.

## 🌱 참고 사항
1 -> 로그인 전
2 -> 유저 레벨
3 -> 스태프 레벨
4 -> 오너 레벨
