### PR TITLE
[feat] 단일 카페 조회 및 디자인 null 처리

### DIFF
--- a/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeApi.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import nova.backend.domain.cafe.dto.response.CafeDesignOverviewDTO;
 import nova.backend.domain.cafe.schema.CafeListSuccessResponse;
 import nova.backend.global.common.SuccessResponse;
 import nova.backend.global.error.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "2. 유저(USER) 카페", description = "카페 목록 관련 API")
@@ -43,4 +45,32 @@ public interface CafeApi {
     ResponseEntity<SuccessResponse<?>> getCafeList(
             @RequestParam(required = false) Boolean approved
     );
+
+    @Operation(
+            summary = "단일 카페 조회",
+            description = "카페 ID로 단일 카페의 상세 정보를 조회합니다.\n\n" +
+                    "✅ 카페의 기본 정보 및 대표 스탬프북 디자인 정보가 함께 제공됩니다.\n" +
+                    "✅ 대표 디자인은 `노출(exposed)`로 설정된 디자인입니다.\n\n" +
+                    "💡 `designJson`이 `null`이면 기본 디자인을 사용 중임을 의미합니다.",
+            parameters = {
+                    @Parameter(name = "cafeId", description = "조회할 카페 ID", example = "1", required = true)
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카페 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CafeDesignOverviewDTO.class))),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 카페를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{cafeId}")
+    ResponseEntity<SuccessResponse<?>> getCafeById(
+            @Parameter(name = "cafeId", description = "조회할 카페 ID", example = "1")
+            @PathVariable Long cafeId
+    );
+
+
+
+
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/CafeController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/CafeController.java
@@ -1,6 +1,7 @@
 package nova.backend.domain.cafe.controller;
 
 import lombok.RequiredArgsConstructor;
+import nova.backend.domain.cafe.dto.response.CafeDesignOverviewDTO;
 import nova.backend.domain.cafe.dto.response.CafeSummaryWithConceptDTO;
 import nova.backend.domain.cafe.service.CafeService;
 import nova.backend.global.common.SuccessResponse;
@@ -40,4 +41,14 @@ public class CafeController implements CafeApi {
         List<CafeSummaryWithConceptDTO> response = cafeService.getTop10CafesByStampBookDownload();
         return SuccessResponse.ok(response);
     }
+
+    /**
+     * 단일 카페 조회
+     */
+    @GetMapping("/{cafeId}")
+    public ResponseEntity<SuccessResponse<?>> getCafeById(@PathVariable Long cafeId) {
+        CafeDesignOverviewDTO response = cafeService.getCafeById(cafeId);
+        return SuccessResponse.ok(response);
+    }
+
 }

--- a/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeController.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeController.java
@@ -81,7 +81,7 @@ public class OwnerCafeController implements OwnerCafeApi {
     ) {
         Cafe cafe = cafeRepository.findById(userDetails.getSelectedCafeId())
                 .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUND));
-        return SuccessResponse.ok(CafeDesignOverviewDTO.fromEntity(cafe));
+        return SuccessResponse.ok(CafeDesignOverviewDTO.fromEntity(cafe, cafe.getExposedDesign()));
     }
 
     @GetMapping("/stampbook-design/{designId}")

--- a/src/main/java/nova/backend/domain/cafe/dto/common/StampBookDesignBasicDTO.java
+++ b/src/main/java/nova/backend/domain/cafe/dto/common/StampBookDesignBasicDTO.java
@@ -13,14 +13,20 @@ public record StampBookDesignBasicDTO(
         CharacterType characterType
 ) {
     public static StampBookDesignBasicDTO from(StampBookDesign design) {
+        if (design == null) {
+            return new StampBookDesignBasicDTO(null, null, null, null, null, null);
+        }
+
         return new StampBookDesignBasicDTO(
                 design.getStampBookName(),
                 design.getCafeIntroduction(),
                 design.getConceptIntroduction(),
                 design.getRewardDescription(),
                 design.getDesignJson(),
-                design.getCafe().getCharacterType()
+                design.getCafe() != null ? design.getCafe().getCharacterType() : null
         );
     }
+
+
 }
 

--- a/src/main/java/nova/backend/domain/cafe/dto/response/CafeDesignOverviewDTO.java
+++ b/src/main/java/nova/backend/domain/cafe/dto/response/CafeDesignOverviewDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import nova.backend.domain.cafe.dto.common.CafeBasicInfoDTO;
 import nova.backend.domain.cafe.dto.common.StampBookDesignBasicDTO;
 import nova.backend.domain.cafe.entity.Cafe;
+import nova.backend.domain.cafe.entity.StampBookDesign;
 
 public record CafeDesignOverviewDTO(
         @JsonUnwrapped
@@ -11,10 +12,10 @@ public record CafeDesignOverviewDTO(
         @JsonUnwrapped
         StampBookDesignBasicDTO designInfo
 ) {
-    public static CafeDesignOverviewDTO fromEntity(Cafe cafe) {
+    public static CafeDesignOverviewDTO fromEntity(Cafe cafe, StampBookDesign design) {
         return new CafeDesignOverviewDTO(
                 CafeBasicInfoDTO.from(cafe),
-                StampBookDesignBasicDTO.from(cafe.getExposedDesign()) // ✅ 수정
+                StampBookDesignBasicDTO.from(design)
         );
     }
 }

--- a/src/main/java/nova/backend/domain/cafe/entity/StampBookDesign.java
+++ b/src/main/java/nova/backend/domain/cafe/entity/StampBookDesign.java
@@ -25,16 +25,16 @@ public class StampBookDesign {
     @Column(nullable = false)
     private boolean exposed; // 현재 노출 중인지 여부
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String stampBookName;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String cafeIntroduction;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String conceptIntroduction;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rewardDescription;
 
     public void expose() { this.exposed = true; }

--- a/src/main/java/nova/backend/domain/cafe/service/CafeService.java
+++ b/src/main/java/nova/backend/domain/cafe/service/CafeService.java
@@ -1,9 +1,12 @@
 package nova.backend.domain.cafe.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import nova.backend.domain.cafe.dto.response.CafeDesignOverviewDTO;
 import nova.backend.domain.cafe.dto.response.CafeSummaryWithConceptDTO;
+import nova.backend.domain.cafe.entity.Cafe;
 import nova.backend.domain.cafe.entity.CafeRegistrationStatus;
+import nova.backend.domain.cafe.entity.StampBookDesign;
 import nova.backend.domain.cafe.repository.CafeRepository;
 import nova.backend.global.error.ErrorCode;
 import nova.backend.global.error.exception.BusinessException;
@@ -56,10 +59,13 @@ public class CafeService {
      */
     @Transactional(readOnly = true)
     public CafeDesignOverviewDTO getCafeById(Long cafeId) {
-        return cafeRepository.findById(cafeId)
-                .map(CafeDesignOverviewDTO::fromEntity)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new EntityNotFoundException("카페를 찾을 수 없습니다."));
+
+        StampBookDesign exposedDesign = cafe.getExposedDesign();
+        return CafeDesignOverviewDTO.fromEntity(cafe, exposedDesign);  // 명시적으로 전달
     }
+
 
 }
 

--- a/src/main/java/nova/backend/domain/cafe/service/CafeService.java
+++ b/src/main/java/nova/backend/domain/cafe/service/CafeService.java
@@ -1,9 +1,12 @@
 package nova.backend.domain.cafe.service;
 
 import lombok.RequiredArgsConstructor;
+import nova.backend.domain.cafe.dto.response.CafeDesignOverviewDTO;
 import nova.backend.domain.cafe.dto.response.CafeSummaryWithConceptDTO;
 import nova.backend.domain.cafe.entity.CafeRegistrationStatus;
 import nova.backend.domain.cafe.repository.CafeRepository;
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,5 +50,16 @@ public class CafeService {
                 .map(dto -> CafeSummaryWithConceptDTO.from(dto.cafe()))
                 .toList();
     }
+
+    /**
+    * 단일 카페 조회
+     */
+    @Transactional(readOnly = true)
+    public CafeDesignOverviewDTO getCafeById(Long cafeId) {
+        return cafeRepository.findById(cafeId)
+                .map(CafeDesignOverviewDTO::fromEntity)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+    }
+
 }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #90 
 
## 🌱 작업 사항
단일 카페 상세 조회 작업

## 🌱 참고 사항
### 카페 단일 조회 시 null이면 안 되는 반환값이 null이다? (예. 스탬프북, 카페 컨셉 등)
1. 해당 카페에서 스탬프북 expose를 설정 안 했을 경우 (여러 스탬프북 중 노출 설정 된 스탬프북이 있어야 함.)
2. 해당 카페에서 기본 템플릿으로 설정했을 경우 (기본 템플릿으로 설정하며, DesignJson은 null로 설정했음)

두 가지 경우를 체크하시면 됩니다! @RohSungKyun 
null 일 경우에 화면에 안 그려주시거나 해야할 거 같아요. 
아니면 이게 설정되지 않았을 때 화면을 따로 만들어주시면 더 좋아요. @Hyonning 

