### PR TITLE
[feat] 사장용 챌린지 기능 개발

### DIFF
--- a/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/OwnerCafeApi.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "4. 사장(OWNER) API", description = "카페 등록/관리 API")
+@Tag(name = "4. 카페(OWNER) API", description = "카페 등록/관리 API")
 public interface OwnerCafeApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeApi.java
@@ -2,6 +2,8 @@ package nova.backend.domain.challenge.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -21,7 +23,7 @@ import java.util.List;
 @SecurityRequirement(name = "token")
 public interface OwnerChallengeApi {
 
-    @Operation(summary = "챌린지 생성")
+    @Operation(summary = "챌린지 생성", description = "사장이 새로운 챌린지를 생성합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "챌린지 생성 성공"),
             @ApiResponse(responseCode = "403", description = "카페 소유주 아님"),
@@ -33,40 +35,44 @@ public interface OwnerChallengeApi {
             @RequestBody ChallengeCreateRequestDTO request
     );
 
-    @Operation(summary = "챌린지 상세 조회")
+    @Operation(summary = "챌린지 상세 조회", description = "사장이 챌린지 단일 조회를 합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChallengeDetailResponseDTO.class))),
             @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음")
     })
     @GetMapping("/{challengeId}")
-    ResponseEntity<SuccessResponse<ChallengeDetailResponseDTO>> getChallengeDetail(
+    ResponseEntity<SuccessResponse<?>> getChallengeDetail(
             @PathVariable Long challengeId
     );
 
-    @Operation(summary = "진행 예정 챌린지 조회")
+    @Operation(summary = "진행 예정 챌린지 조회", description = "사장이 진행 예정인 챌린지를 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChallengeSummaryDTO.class)))
     })
     @GetMapping("/upcoming")
-    ResponseEntity<SuccessResponse<List<ChallengeSummaryDTO>>> getUpcomingChallenges(
+    ResponseEntity<SuccessResponse<?>> getUpcomingChallenges(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "진행 중 챌린지 조회")
+    @Operation(summary = "진행 중 챌린지 조회", description = "사장이 진행 중인 챌린지를 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChallengeSummaryDTO.class)))
     })
     @GetMapping("/ongoing")
-    ResponseEntity<SuccessResponse<List<ChallengeSummaryDTO>>> getOngoingChallenges(
+    ResponseEntity<SuccessResponse<?>> getOngoingChallenges(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "완료된 챌린지 조회")
+    @Operation(summary = "완료된 챌린지 조회", description = "사장이 완료된 챌린지를 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CompletedChallengeListResponseDTO.class)))
     })
     @GetMapping("/completed")
-    ResponseEntity<SuccessResponse<List<CompletedChallengeListResponseDTO>>> getCompletedChallenges(
+    ResponseEntity<SuccessResponse<?>> getCompletedChallenges(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeApi.java
@@ -1,0 +1,72 @@
+package nova.backend.domain.challenge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import nova.backend.domain.challenge.dto.request.ChallengeCreateRequestDTO;
+import nova.backend.domain.challenge.dto.response.*;
+import nova.backend.global.auth.CustomUserDetails;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "4. 챌린지(OWNER) API", description = "사장용 챌린지 생성 및 조회")
+@RequestMapping("/api/owner/challenges")
+@SecurityRequirement(name = "token")
+public interface OwnerChallengeApi {
+
+    @Operation(summary = "챌린지 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "챌린지 생성 성공"),
+            @ApiResponse(responseCode = "403", description = "카페 소유주 아님"),
+            @ApiResponse(responseCode = "404", description = "카페를 찾을 수 없음")
+    })
+    @PostMapping
+    ResponseEntity<SuccessResponse<?>> createChallenge(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ChallengeCreateRequestDTO request
+    );
+
+    @Operation(summary = "챌린지 상세 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음")
+    })
+    @GetMapping("/{challengeId}")
+    ResponseEntity<SuccessResponse<ChallengeDetailResponseDTO>> getChallengeDetail(
+            @PathVariable Long challengeId
+    );
+
+    @Operation(summary = "진행 예정 챌린지 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/upcoming")
+    ResponseEntity<SuccessResponse<List<ChallengeSummaryDTO>>> getUpcomingChallenges(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "진행 중 챌린지 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/ongoing")
+    ResponseEntity<SuccessResponse<List<ChallengeSummaryDTO>>> getOngoingChallenges(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "완료된 챌린지 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/completed")
+    ResponseEntity<SuccessResponse<List<CompletedChallengeListResponseDTO>>> getCompletedChallenges(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeController.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeController.java
@@ -1,0 +1,64 @@
+package nova.backend.domain.challenge.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import nova.backend.domain.challenge.dto.request.ChallengeCreateRequestDTO;
+import nova.backend.domain.challenge.dto.response.*;
+import nova.backend.domain.challenge.service.OwnerChallengeService;
+import nova.backend.global.auth.CustomUserDetails;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner/challenges")
+@Tag(name = "6. 챌린지 API", description = "챌린지 생성 및 조회")
+public class OwnerChallengeController {
+
+    private final OwnerChallengeService challengeService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createChallenge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ChallengeCreateRequestDTO request
+    ) {
+        challengeService.createChallenge(userDetails.getUserId(), userDetails.getSelectedCafeId(), request);
+        return SuccessResponse.created(null);
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<SuccessResponse<?>> getChallengeDetail(
+            @PathVariable Long challengeId
+    ) {
+        ChallengeDetailResponseDTO response = challengeService.getChallengeDetail(challengeId);
+        return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/upcoming")
+    public ResponseEntity<SuccessResponse<?>> getUpcomingChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<ChallengeSummaryDTO> response = challengeService.getUpcomingChallenges(userDetails.getSelectedCafeId());
+        return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/ongoing")
+    public ResponseEntity<SuccessResponse<?>> getOngoingChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<ChallengeSummaryDTO> response = challengeService.getOngoingChallenges(userDetails.getSelectedCafeId());
+        return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/completed")
+    public ResponseEntity<SuccessResponse<?>> getCompletedChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<CompletedChallengeListResponseDTO> response = challengeService.getCompletedChallenges(userDetails.getSelectedCafeId());
+        return SuccessResponse.ok(response);
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeController.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/OwnerChallengeController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/owner/challenges")
 @Tag(name = "6. 챌린지 API", description = "챌린지 생성 및 조회")
-public class OwnerChallengeController {
+public class OwnerChallengeController implements OwnerChallengeApi {
 
     private final OwnerChallengeService challengeService;
 

--- a/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCreateRequestDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCreateRequestDTO.java
@@ -1,0 +1,29 @@
+package nova.backend.domain.challenge.dto.request;
+
+import nova.backend.domain.cafe.entity.Cafe;
+import nova.backend.domain.challenge.entity.Challenge;
+import nova.backend.domain.challenge.entity.ChallengeType;
+
+import java.time.LocalDate;
+
+public record ChallengeCreateRequestDTO(
+        String name,
+        ChallengeType type,
+        String reward,
+        LocalDate startDate,
+        LocalDate endDate,
+        String imageUrl
+) {
+    public Challenge toEntity(Cafe cafe) {
+        return Challenge.builder()
+                .name(name)
+                .cafe(cafe)
+                .type(type)
+                .reward(reward)
+                .startDate(startDate)
+                .endDate(endDate)
+                .imageUrl(imageUrl)
+                .successCount(10)
+                .build();
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeBaseDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeBaseDTO.java
@@ -1,0 +1,36 @@
+package nova.backend.domain.challenge.dto.response;
+
+import nova.backend.domain.challenge.entity.Challenge;
+import nova.backend.domain.challenge.entity.ChallengeType;
+
+import java.time.LocalDate;
+
+/**
+ * 챌린지 공통 응답 DTO.
+ * @param challengeId
+ * @param type
+ * @param rewardDescription
+ * @param startDate
+ * @param endDate
+ * @param thumbnailUrl
+ */
+public record ChallengeBaseDTO(
+        Long challengeId,
+        ChallengeType type,
+        String rewardDescription,
+        LocalDate startDate,
+        LocalDate endDate,
+        String thumbnailUrl
+) {
+    public static ChallengeBaseDTO fromEntity(Challenge challenge) {
+        return new ChallengeBaseDTO(
+                challenge.getChallengeId(),
+                challenge.getType(),
+                challenge.getReward(),
+                challenge.getStartDate(),
+                challenge.getEndDate(),
+                challenge.getImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeDetailResponseDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeDetailResponseDTO.java
@@ -1,0 +1,19 @@
+package nova.backend.domain.challenge.dto.response;
+
+import nova.backend.domain.challenge.entity.Challenge;
+
+public record ChallengeDetailResponseDTO(
+        ChallengeBaseDTO base,
+        int participantCount,
+        int completedCount,
+        int canceledCount
+) {
+    public static ChallengeDetailResponseDTO fromEntity(Challenge challenge) {
+        return new ChallengeDetailResponseDTO(
+                ChallengeBaseDTO.fromEntity(challenge),
+                challenge.getParticipantCount(),
+                challenge.getCompletedCount(),
+                challenge.getCanceledCount()
+        );
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeSummaryDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/response/ChallengeSummaryDTO.java
@@ -1,0 +1,11 @@
+package nova.backend.domain.challenge.dto.response;
+
+/**
+ * 진행예정 / 진행중 챌린지 응답에 사용하는 DTO
+ * @param base
+ */
+public record ChallengeSummaryDTO(
+        ChallengeBaseDTO base
+) {}
+
+

--- a/src/main/java/nova/backend/domain/challenge/dto/response/CompletedChallengeListResponseDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/response/CompletedChallengeListResponseDTO.java
@@ -1,0 +1,13 @@
+package nova.backend.domain.challenge.dto.response;
+
+/**
+ * 완료된 챌린지 리스트에 사용하는 DTO.
+ * @param base
+ * @param participantCount
+ */
+public record CompletedChallengeListResponseDTO(
+        ChallengeBaseDTO base,
+        int participantCount
+) {}
+
+

--- a/src/main/java/nova/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/Challenge.java
@@ -1,0 +1,69 @@
+package nova.backend.domain.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import nova.backend.domain.cafe.entity.Cafe;
+import nova.backend.global.common.BaseTimeEntity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Challenge extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long challengeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChallengeType type;
+
+    @Column(nullable = false)
+    private String reward;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int successCount = 10;
+
+    public int getParticipantCount() {
+        return participations.size();
+    }
+
+    public int getCompletedCount() {
+        return (int) participations.stream()
+                .filter(p -> p.getChallengeStatus() == ChallengeStatus.COMPLETED)
+                .count();
+    }
+
+    public int getCanceledCount() {
+        return (int) participations.stream()
+                .filter(p -> p.getChallengeStatus() == ChallengeStatus.CANCELED)
+                .count();
+    }
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChallengeParticipation> participations = new ArrayList<>();
+}
+

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
@@ -1,0 +1,42 @@
+package nova.backend.domain.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import nova.backend.domain.user.entity.User;
+import nova.backend.global.common.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChallengeParticipation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long participationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipationStatus participationStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChallengeStatus challengeStatus;
+
+    @Column(nullable = false)
+    private int completedCount = 0;
+
+    public enum ParticipationStatus {
+        IN_PROGRESS, STOPPED, REWARDED
+    }
+}
+

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
@@ -1,0 +1,7 @@
+package nova.backend.domain.challenge.entity;
+
+public enum ChallengeStatus {
+    IN_PROGRESS, // 참여 중
+    COMPLETED,   // 챌린지 성공
+    CANCELED     // 중단
+}

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeType.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeType.java
@@ -1,0 +1,8 @@
+package nova.backend.domain.challenge.entity;
+
+public enum ChallengeType {
+    TUMBLER_USE,       // 텀블러에 음료 담기
+    NO_STRAW,          // 빨대 사용 안 하기
+    SNS_CERTIFICATION  // SNS에 카페 방문 인증하기
+}
+

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
@@ -1,0 +1,45 @@
+package nova.backend.domain.challenge.repository;
+
+import nova.backend.domain.challenge.entity.Challenge;
+import nova.backend.domain.cafe.entity.Cafe;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    List<Challenge> findByCafe(Cafe cafe);
+
+    @Query("""
+        SELECT c FROM Challenge c
+        WHERE c.cafe = :cafe
+          AND c.startDate > :today
+    """)
+    List<Challenge> findUpcomingChallenges(Cafe cafe, LocalDate today);
+
+    @Query("""
+        SELECT c FROM Challenge c
+        WHERE c.cafe = :cafe
+          AND c.startDate <= :today
+          AND c.endDate >= :today
+    """)
+    List<Challenge> findOngoingChallenges(Cafe cafe, LocalDate today);
+
+    @Query("""
+        SELECT c FROM Challenge c
+        WHERE c.cafe = :cafe
+          AND c.endDate < :today
+    """)
+    List<Challenge> findCompletedChallenges(Cafe cafe, LocalDate today);
+
+
+    List<Challenge> findByCafe_CafeIdAndStartDateAfter(Long cafeId, LocalDate today);
+
+    List<Challenge> findByCafe_CafeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(Long cafeId, LocalDate todayStart, LocalDate todayEnd);
+
+    List<Challenge> findByCafe_CafeIdAndEndDateBefore(Long cafeId, LocalDate today);
+
+    boolean existsByCafe_CafeId(Long cafeId);
+}

--- a/src/main/java/nova/backend/domain/challenge/service/OwnerChallengeService.java
+++ b/src/main/java/nova/backend/domain/challenge/service/OwnerChallengeService.java
@@ -1,0 +1,74 @@
+package nova.backend.domain.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import nova.backend.domain.cafe.entity.Cafe;
+import nova.backend.domain.cafe.repository.CafeRepository;
+import nova.backend.domain.challenge.dto.request.ChallengeCreateRequestDTO;
+import nova.backend.domain.challenge.dto.response.*;
+import nova.backend.domain.challenge.entity.Challenge;
+import nova.backend.domain.challenge.repository.ChallengeRepository;
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OwnerChallengeService {
+
+    private final CafeRepository cafeRepository;
+    private final ChallengeRepository challengeRepository;
+
+    @Transactional
+    public void createChallenge(Long ownerId, Long cafeId, ChallengeCreateRequestDTO request) {
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if (!cafe.getOwner().getUserId().equals(ownerId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        Challenge challenge = request.toEntity(cafe);
+        challengeRepository.save(challenge);
+    }
+
+    public ChallengeDetailResponseDTO getChallengeDetail(Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
+        ChallengeBaseDTO base = ChallengeBaseDTO.fromEntity(challenge);
+        return new ChallengeDetailResponseDTO(
+                base,
+                challenge.getParticipantCount(),
+                challenge.getCompletedCount(),
+                challenge.getCanceledCount()
+        );
+    }
+
+    public List<ChallengeSummaryDTO> getUpcomingChallenges(Long cafeId) {
+        LocalDate today = LocalDate.now();
+        return challengeRepository.findByCafe_CafeIdAndStartDateAfter(cafeId, today).stream()
+                .map(challenge -> new ChallengeSummaryDTO(ChallengeBaseDTO.fromEntity(challenge)))
+                .toList();
+    }
+
+    public List<ChallengeSummaryDTO> getOngoingChallenges(Long cafeId) {
+        LocalDate today = LocalDate.now();
+        return challengeRepository.findByCafe_CafeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(cafeId, today, today).stream()
+                .map(challenge -> new ChallengeSummaryDTO(ChallengeBaseDTO.fromEntity(challenge)))
+                .toList();
+    }
+
+    public List<CompletedChallengeListResponseDTO> getCompletedChallenges(Long cafeId) {
+        return challengeRepository.findByCafe_CafeIdAndEndDateBefore(cafeId, LocalDate.now()).stream()
+                .map(challenge -> new CompletedChallengeListResponseDTO(
+                        ChallengeBaseDTO.fromEntity(challenge),
+                        challenge.getParticipantCount()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/nova/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/nova/backend/global/config/SwaggerConfig.java
@@ -20,8 +20,8 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
-                .title("Nova Homepage API Document")
-                .description("Nova API 명세서입니다.")
+                .title("Ecok API Document")
+                .description("Ecok API 명세서입니다.")
                 .version("v1.0.0");
 
         SecurityScheme securityScheme = new SecurityScheme()
@@ -39,6 +39,8 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(info)
                 .components(components)
-                .addServersItem(server);
+                .addServersItem(server)
+                .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("token"))
+                ;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #100 
 
## 🌱 작업 사항
사장이 챌린지를 등록하고, 관리할 수 있다. 

## 🌱 참고 사항
챌린지 생성
챌린지 진행예정/진행중/완료 기준으로 조회
챌린지 단일조회
