### PR TITLE
[feat] staff 챌린지 적립/취소, user 챌린지 조회

### DIFF
--- a/src/main/java/nova/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/ChallengeController.java
@@ -1,6 +1,7 @@
 package nova.backend.domain.challenge.controller;
 
 import lombok.RequiredArgsConstructor;
+import nova.backend.domain.challenge.controller.api.ChallengeApi;
 import nova.backend.domain.challenge.dto.response.ChallengeSummaryDTO;
 import nova.backend.domain.challenge.dto.common.ChallengeBaseDTO;
 import nova.backend.domain.challenge.entity.status.ChallengeStatus;
@@ -16,7 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/challenges")
-public class ChallengeController {
+public class ChallengeController implements ChallengeApi {
 
     private final ChallengeService challengeService;
 
@@ -34,6 +35,7 @@ public class ChallengeController {
         List<ChallengeSummaryDTO> response = challengeService.getAvailableChallenges();
         return SuccessResponse.ok(response);
     }
+
 
     @GetMapping("/my")
     public ResponseEntity<SuccessResponse<?>> getMyChallenges(

--- a/src/main/java/nova/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,55 @@
+package nova.backend.domain.challenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import nova.backend.domain.challenge.dto.response.ChallengeSummaryDTO;
+import nova.backend.domain.challenge.dto.common.ChallengeBaseDTO;
+import nova.backend.domain.challenge.entity.status.ChallengeStatus;
+import nova.backend.domain.challenge.service.ChallengeService;
+import nova.backend.global.auth.CustomUserDetails;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @PatchMapping("/{challengeId}/withdraw")
+    public ResponseEntity<SuccessResponse<?>> withdrawChallenge(
+            @PathVariable Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        challengeService.withdrawChallenge(challengeId, userDetails.getUserId());
+        return SuccessResponse.ok(null);
+    }
+
+    @GetMapping("/browse")
+    public ResponseEntity<SuccessResponse<?>> getAvailableChallenges() {
+        List<ChallengeSummaryDTO> response = challengeService.getAvailableChallenges();
+        return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<SuccessResponse<?>> getMyChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam ChallengeStatus status
+    ) {
+        List<ChallengeSummaryDTO> response = challengeService.getMyChallenges(userDetails.getUserId(), status);
+        return SuccessResponse.ok(response);
+    }
+
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<SuccessResponse<?>> getChallengeDetail(
+            @PathVariable Long challengeId
+    ) {
+        ChallengeBaseDTO response = challengeService.getChallengeDetail(challengeId);
+        return SuccessResponse.ok(response);
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/controller/StaffChallengeController.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/StaffChallengeController.java
@@ -3,6 +3,7 @@ package nova.backend.domain.challenge.controller;
 import lombok.RequiredArgsConstructor;
 import nova.backend.domain.challenge.controller.api.StaffChallengeApi;
 import nova.backend.domain.challenge.dto.request.ChallengeAccumulateRequestDTO;
+import nova.backend.domain.challenge.dto.request.ChallengeCancelRequestDTO;
 import nova.backend.domain.challenge.service.StaffChallengeService;
 import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
@@ -13,23 +14,32 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/challenges/staff")
+@RequestMapping("/api/staff/challenges")
 public class StaffChallengeController implements StaffChallengeApi {
 
     private final StaffChallengeService staffChallengeService;
 
     @PostMapping("/accumulate")
-    @PreAuthorize("hasRole('STAFF') or hasRole('OWNER')")
     public ResponseEntity<SuccessResponse<?>> accumulateChallenge(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody ChallengeAccumulateRequestDTO request
     ) {
-        staffChallengeService.accumulateOngoingChallengeForCafe(
-                userDetails.getSelectedCafeId(),
-                request.qrCodeValue()
-        );
+        staffChallengeService.accumulateOngoingChallengeForCafe(userDetails.getSelectedCafeId(), request);
         return SuccessResponse.created(null);
     }
+
+
+    @DeleteMapping("/cancel")
+    public ResponseEntity<SuccessResponse<?>> cancelAccumulations(
+            @RequestBody ChallengeCancelRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        staffChallengeService.cancelAccumulationsByQr(userDetails.getSelectedCafeId(), request);
+        return SuccessResponse.ok(null);
+    }
+
+
+
 
 }
 

--- a/src/main/java/nova/backend/domain/challenge/controller/api/ChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/api/ChallengeApi.java
@@ -1,0 +1,74 @@
+package nova.backend.domain.challenge.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import nova.backend.domain.challenge.entity.status.ChallengeStatus;
+import nova.backend.domain.challenge.schema.ChallengeDetailSuccessResponse;
+import nova.backend.domain.challenge.schema.ChallengeListSuccessResponse;
+import nova.backend.global.auth.CustomUserDetails;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "2. 챌린지", description = "챌린지 관련 API")
+public interface ChallengeApi {
+
+    @PatchMapping("/{challengeId}/withdraw")
+    @Operation(summary = "챌린지 참여 중단", description = "유저가 진행 중인 챌린지 참여를 중단합니다.")
+    ResponseEntity<SuccessResponse<?>> withdrawChallenge(
+            @Parameter(description = "중단할 챌린지 ID", example = "1")
+            @PathVariable Long challengeId,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+
+    @Operation(
+            summary = "진행 가능한 챌린지 목록 조회",
+            description = "현재 참여 가능한 챌린지를 모두 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ChallengeListSuccessResponse.class)))
+            }
+    )
+    @GetMapping("/browse")
+    ResponseEntity<SuccessResponse<?>> getAvailableChallenges();
+
+    @Operation(
+            summary = "내 챌린지 목록 조회",
+            description = "사용자가 참여 중인 챌린지를 상태(IN_PROGRESS, COMPLETED, REWARDED)로 필터링하여 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ChallengeListSuccessResponse.class)))
+            }
+    )
+    @GetMapping("/my")
+    ResponseEntity<SuccessResponse<?>> getMyChallenges(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Parameter(description = "필터링할 챌린지 상태" +
+                    "파라미터를 꼭! 넣어야 합니다. `my?status=IN_PROGRESS`", example = "IN_PROGRESS")
+            @RequestParam ChallengeStatus status
+    );
+
+    @Operation(
+            summary = "챌린지 상세 조회",
+            description = "특정 챌린지의 상세 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ChallengeDetailSuccessResponse.class)))
+            }
+    )
+    @GetMapping("/{challengeId}")
+    ResponseEntity<SuccessResponse<?>> getChallengeDetail(
+            @Parameter(description = "조회할 챌린지 ID", example = "1")
+            @PathVariable Long challengeId
+    );
+}

--- a/src/main/java/nova/backend/domain/challenge/controller/api/StaffChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/api/StaffChallengeApi.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "4-2. 챌린지(STAFF) API", description = "직원/사장용 챌린지 적립 API")
+@Tag(name = "3. 챌린지(STAFF) API", description = "직원/사장용 챌린지 적립 API")
 @RequestMapping("/api/challenges/staff")
 @SecurityRequirement(name = "token")
 public interface StaffChallengeApi {

--- a/src/main/java/nova/backend/domain/challenge/dto/common/ChallengeBaseDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/common/ChallengeBaseDTO.java
@@ -1,5 +1,6 @@
 package nova.backend.domain.challenge.dto.common;
 
+import nova.backend.domain.cafe.entity.Cafe;
 import nova.backend.domain.challenge.entity.Challenge;
 import nova.backend.domain.challenge.entity.ChallengeType;
 
@@ -13,6 +14,8 @@ import java.time.LocalDate;
  * @param startDate
  * @param endDate
  * @param thumbnailUrl
+ * @param cafeId
+ * @param cafeName
  */
 public record ChallengeBaseDTO(
         Long challengeId,
@@ -20,16 +23,21 @@ public record ChallengeBaseDTO(
         String rewardDescription,
         LocalDate startDate,
         LocalDate endDate,
-        String thumbnailUrl
+        String thumbnailUrl,
+        Long cafeId,
+        String cafeName
 ) {
     public static ChallengeBaseDTO fromEntity(Challenge challenge) {
+        Cafe cafe = challenge.getCafe();
         return new ChallengeBaseDTO(
                 challenge.getChallengeId(),
                 challenge.getType(),
                 challenge.getReward(),
                 challenge.getStartDate(),
                 challenge.getEndDate(),
-                challenge.getImageUrl()
+                challenge.getImageUrl(),
+                cafe != null ? cafe.getCafeId() : null,
+                cafe != null ? cafe.getCafeName() : null
         );
     }
 }

--- a/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeAccumulateRequestDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeAccumulateRequestDTO.java
@@ -1,4 +1,17 @@
 package nova.backend.domain.challenge.dto.request;
 
-public record ChallengeAccumulateRequestDTO(String qrCodeValue) {}
+import nova.backend.domain.challenge.entity.ChallengeAccumulation;
+import nova.backend.domain.challenge.entity.ChallengeParticipation;
 
+public record ChallengeAccumulateRequestDTO(
+        String qrCodeValue,
+        int accumulateCount
+) {
+
+    public ChallengeAccumulation toEntity(ChallengeParticipation participation) {
+        return ChallengeAccumulation.builder()
+                .participation(participation)
+                .accumulatedCount(accumulateCount)
+                .build();
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCancelRequestDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCancelRequestDTO.java
@@ -1,0 +1,13 @@
+package nova.backend.domain.challenge.dto.request;
+
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
+
+public record ChallengeCancelRequestDTO(String qrCodeValue, int cancelCount) {
+    public void validate() {
+        if (cancelCount <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}
+

--- a/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCancelRequestDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/request/ChallengeCancelRequestDTO.java
@@ -3,9 +3,9 @@ package nova.backend.domain.challenge.dto.request;
 import nova.backend.global.error.ErrorCode;
 import nova.backend.global.error.exception.BusinessException;
 
-public record ChallengeCancelRequestDTO(String qrCodeValue, int cancelCount) {
+public record ChallengeCancelRequestDTO(String qrCodeValue, int count) {
     public void validate() {
-        if (cancelCount <= 0) {
+        if (count <= 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }

--- a/src/main/java/nova/backend/domain/challenge/dto/response/OwnerChallengeDetailResponseDTO.java
+++ b/src/main/java/nova/backend/domain/challenge/dto/response/OwnerChallengeDetailResponseDTO.java
@@ -5,16 +5,16 @@ import nova.backend.domain.challenge.entity.Challenge;
 
 public record OwnerChallengeDetailResponseDTO(
         ChallengeBaseDTO base,
-        int participantCount,
-        int completedCount,
-        int canceledCount
+        int inProgressCount,
+        int canceledCount,
+        int rewardedCount
 ) {
     public static OwnerChallengeDetailResponseDTO fromEntity(Challenge challenge) {
         return new OwnerChallengeDetailResponseDTO(
                 ChallengeBaseDTO.fromEntity(challenge),
-                challenge.getParticipantCount(),
-                challenge.getCompletedCount(),
-                challenge.getCanceledCount()
+                challenge.getInProgressCount(),
+                challenge.getCanceledCount(),
+                challenge.getRewardedCount()
         );
     }
 }

--- a/src/main/java/nova/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/Challenge.java
@@ -42,22 +42,30 @@ public class Challenge extends BaseTimeEntity {
     @Column(nullable = false)
     private int successCount = 10;
 
+    /**
+     * 챌린지 자연스러운 중단 상태 자체
+     */
+    public enum ChallengeStatus {
+        IN_PROGRESS, // 아직 완료되지 않음
+        COMPLETED,   // 성공 기준 도달
+        CANCELED     // 중단됨 (참여를 중단한 상태)
+    }
+
     public int getParticipantCount() {
         return participations.size();
     }
 
     public int getCompletedCount() {
         return (int) participations.stream()
-                .filter(p -> p.getChallengeStatus() == ParticipationStatus.COMPLETED)
+                .filter(p -> p.getChallengeStatus() == ChallengeStatus.COMPLETED)
                 .count();
     }
 
     public int getCanceledCount() {
         return (int) participations.stream()
-                .filter(p -> p.getChallengeStatus() == ParticipationStatus.CANCELED)
+                .filter(p -> p.getChallengeStatus() == ChallengeStatus.CANCELED)
                 .count();
     }
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cafe_id")
@@ -65,5 +73,6 @@ public class Challenge extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChallengeParticipation> participations = new ArrayList<>();
+
 }
 

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeAccumulation.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeAccumulation.java
@@ -2,6 +2,8 @@ package nova.backend.domain.challenge.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import nova.backend.domain.challenge.entity.status.ChallengeStatus;
+import nova.backend.domain.challenge.entity.status.ParticipationStatus;
 import nova.backend.domain.challenge.repository.ChallengeAccumulationRepository;
 import nova.backend.global.common.BaseTimeEntity;
 import nova.backend.global.error.ErrorCode;
@@ -44,4 +46,5 @@ public class ChallengeAccumulation extends BaseTimeEntity {
         }
         this.accumulatedCount -= count;
     }
+
 }

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeAccumulation.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeAccumulation.java
@@ -1,0 +1,47 @@
+package nova.backend.domain.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import nova.backend.domain.challenge.repository.ChallengeAccumulationRepository;
+import nova.backend.global.common.BaseTimeEntity;
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChallengeAccumulation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long accumulationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id", nullable = false)
+    private ChallengeParticipation participation;
+
+    @Column(nullable = false)
+    private int accumulatedCount;
+
+    public static ChallengeAccumulation create(
+            ChallengeParticipation participation,
+            int accumulateCount
+    ) {
+        return ChallengeAccumulation.builder()
+                .participation(participation)
+                .accumulatedCount(accumulateCount)
+                .build();
+    }
+
+    public void decreaseAccumulatedCount(int count) {
+        if (count <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (count > this.accumulatedCount) {
+            throw new BusinessException(ErrorCode.CHALLENGE_OVER_REQUEST);
+        }
+        this.accumulatedCount -= count;
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
@@ -28,22 +28,37 @@ public class ChallengeParticipation extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ParticipationStatus participationStatus;
+    private ParticipationStatus participationStatus; // 사용자의 참여 의사
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private nova.backend.domain.challenge.entity.ParticipationStatus challengeStatus;
+    private ChallengeStatus challengeStatus; // 챌린지 목표 도달 여부
 
     @Column(nullable = false)
     private int completedCount = 0;
 
-    public void incrementCompletedCount(int successThreshold) {
-        this.completedCount++;
+    public static ChallengeParticipation createNew(Challenge challenge, User user) {
+        return ChallengeParticipation.builder()
+                .challenge(challenge)
+                .user(user)
+                .participationStatus(ParticipationStatus.IN_PROGRESS)
+                .challengeStatus(ChallengeStatus.IN_PROGRESS)
+                .completedCount(0)
+                .build();
+    }
+
+    public void updateCompletedCount(int totalCount) {
+        this.completedCount = totalCount;
         this.setUpdatedAt(LocalDateTime.now());
-        if (this.completedCount >= successThreshold) {
-            this.challengeStatus = ParticipationStatus.COMPLETED;
+
+        if (this.completedCount >= this.challenge.getSuccessCount()) {
+            this.challengeStatus = ChallengeStatus.COMPLETED;
+        } else {
+            this.challengeStatus = ChallengeStatus.IN_PROGRESS;
         }
     }
 
+    public boolean isInProgress() {
+        return this.challengeStatus == ChallengeStatus.IN_PROGRESS;
+    }
 }
-

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeParticipation.java
@@ -2,6 +2,7 @@ package nova.backend.domain.challenge.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import nova.backend.domain.challenge.entity.status.ParticipationStatus;
 import nova.backend.domain.user.entity.User;
 import nova.backend.global.common.BaseTimeEntity;
 
@@ -32,7 +33,7 @@ public class ChallengeParticipation extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ChallengeStatus challengeStatus; // 챌린지 목표 도달 여부
+    private Challenge.ChallengeStatus challengeStatus; // 챌린지 목표 도달 여부
 
     @Column(nullable = false)
     private int completedCount = 0;
@@ -42,7 +43,7 @@ public class ChallengeParticipation extends BaseTimeEntity {
                 .challenge(challenge)
                 .user(user)
                 .participationStatus(ParticipationStatus.IN_PROGRESS)
-                .challengeStatus(ChallengeStatus.IN_PROGRESS)
+                .challengeStatus(Challenge.ChallengeStatus.IN_PROGRESS)
                 .completedCount(0)
                 .build();
     }
@@ -52,13 +53,13 @@ public class ChallengeParticipation extends BaseTimeEntity {
         this.setUpdatedAt(LocalDateTime.now());
 
         if (this.completedCount >= this.challenge.getSuccessCount()) {
-            this.challengeStatus = ChallengeStatus.COMPLETED;
+            this.challengeStatus = Challenge.ChallengeStatus.COMPLETED;
         } else {
-            this.challengeStatus = ChallengeStatus.IN_PROGRESS;
+            this.challengeStatus = Challenge.ChallengeStatus.IN_PROGRESS;
         }
     }
 
     public boolean isInProgress() {
-        return this.challengeStatus == ChallengeStatus.IN_PROGRESS;
+        return this.challengeStatus == Challenge.ChallengeStatus.IN_PROGRESS;
     }
 }

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
@@ -1,0 +1,7 @@
+package nova.backend.domain.challenge.entity;
+
+public enum ChallengeStatus {
+    IN_PROGRESS, // 아직 완료되지 않음
+    COMPLETED    // 성공 기준 도달
+}
+

--- a/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ChallengeStatus.java
@@ -1,7 +1,0 @@
-package nova.backend.domain.challenge.entity;
-
-public enum ChallengeStatus {
-    IN_PROGRESS, // 아직 완료되지 않음
-    COMPLETED    // 성공 기준 도달
-}
-

--- a/src/main/java/nova/backend/domain/challenge/entity/ParticipationStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/ParticipationStatus.java
@@ -1,7 +1,7 @@
 package nova.backend.domain.challenge.entity;
 
 public enum ParticipationStatus {
-    IN_PROGRESS, // 참여 중
-    COMPLETED,   // 챌린지 성공
-    CANCELED     // 중단
+    IN_PROGRESS, // 참여 중 (유저가 중단하지 않은 상태)
+    CANCELED     // 유저가 중단한 상태
 }
+

--- a/src/main/java/nova/backend/domain/challenge/entity/status/ChallengeStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/status/ChallengeStatus.java
@@ -1,0 +1,10 @@
+package nova.backend.domain.challenge.entity.status;
+
+/**
+ * 챌린지 자연스러운 중단 상태 자체
+ */
+public enum ChallengeStatus {
+    IN_PROGRESS, // 아직 완료되지 않음
+    COMPLETED,   // 성공 기준 도달
+    REWARDED // 리워드 전환 완료
+}

--- a/src/main/java/nova/backend/domain/challenge/entity/status/ParticipationStatus.java
+++ b/src/main/java/nova/backend/domain/challenge/entity/status/ParticipationStatus.java
@@ -1,5 +1,8 @@
-package nova.backend.domain.challenge.entity;
+package nova.backend.domain.challenge.entity.status;
 
+/**
+ * 사용자의 의지에 따른 챌린지 상태
+ */
 public enum ParticipationStatus {
     IN_PROGRESS, // 참여 중 (유저가 중단하지 않은 상태)
     CANCELED     // 유저가 중단한 상태

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeAccumulationRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeAccumulationRepository.java
@@ -1,0 +1,16 @@
+package nova.backend.domain.challenge.repository;
+
+import nova.backend.domain.challenge.entity.ChallengeAccumulation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChallengeAccumulationRepository extends JpaRepository<ChallengeAccumulation, Long> {
+
+    List<ChallengeAccumulation> findByParticipation_ParticipationIdOrderByCreatedAtDesc(Long participationId);
+
+
+
+}

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeParticipationRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeParticipationRepository.java
@@ -4,10 +4,12 @@ import nova.backend.domain.challenge.entity.ChallengeParticipation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChallengeParticipationRepository extends JpaRepository<ChallengeParticipation, Long> {
     Optional<ChallengeParticipation> findByChallenge_ChallengeIdAndUser_UserId(Long challengeId, Long userId);
+    List<ChallengeParticipation> findByUser_UserId(Long userId);
 
 }

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeParticipationRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeParticipationRepository.java
@@ -2,9 +2,11 @@ package nova.backend.domain.challenge.repository;
 
 import nova.backend.domain.challenge.entity.ChallengeParticipation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface ChallengeParticipationRepository extends JpaRepository<ChallengeParticipation, Long> {
     Optional<ChallengeParticipation> findByChallenge_ChallengeIdAndUser_UserId(Long challengeId, Long userId);
 

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
@@ -4,11 +4,13 @@ import nova.backend.domain.challenge.entity.Challenge;
 import nova.backend.domain.cafe.entity.Cafe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     List<Challenge> findByCafe(Cafe cafe);

--- a/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/nova/backend/domain/challenge/repository/ChallengeRepository.java
@@ -49,4 +49,8 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findFirstByCafe_CafeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
             Long cafeId, LocalDate startDate, LocalDate endDate);
 
+    @Query("SELECT c FROM Challenge c WHERE c.startDate <= CURRENT_DATE AND c.endDate >= CURRENT_DATE")
+    List<Challenge> findAllAvailable();
+
+
 }

--- a/src/main/java/nova/backend/domain/challenge/schema/ChallengeListSuccessResponse.java
+++ b/src/main/java/nova/backend/domain/challenge/schema/ChallengeListSuccessResponse.java
@@ -1,0 +1,10 @@
+package nova.backend.domain.challenge.schema;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import nova.backend.domain.challenge.dto.response.ChallengeSummaryDTO;
+import nova.backend.global.common.SuccessResponse;
+
+import java.util.List;
+
+@Schema(description = "챌린지 목록 조회 성공 응답")
+public class ChallengeListSuccessResponse extends SuccessResponse<List<ChallengeSummaryDTO>> {}

--- a/src/main/java/nova/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/nova/backend/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,70 @@
+package nova.backend.domain.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import nova.backend.domain.challenge.dto.response.ChallengeSummaryDTO;
+import nova.backend.domain.challenge.dto.common.ChallengeBaseDTO;
+import nova.backend.domain.challenge.entity.*;
+import nova.backend.domain.challenge.entity.status.ChallengeStatus;
+import nova.backend.domain.challenge.entity.status.ParticipationStatus;
+import nova.backend.domain.challenge.repository.ChallengeParticipationRepository;
+import nova.backend.domain.challenge.repository.ChallengeRepository;
+import nova.backend.domain.user.entity.User;
+import nova.backend.domain.user.repository.UserRepository;
+import nova.backend.global.error.ErrorCode;
+import nova.backend.global.error.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipationRepository participationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void withdrawChallenge(Long challengeId, Long userId) {
+        ChallengeParticipation participation = participationRepository
+                .findByChallenge_ChallengeIdAndUser_UserId(challengeId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_PARTICIPATION_NOT_FOUND));
+
+        if (!participation.isInProgress()) {
+            throw new BusinessException(ErrorCode.INVALID_CHALLENGE_STATUS);
+        }
+
+        participation.cancelParticipation();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChallengeSummaryDTO> getAvailableChallenges() {
+        return challengeRepository.findAllAvailable().stream()
+                .map(challenge -> new ChallengeSummaryDTO(ChallengeBaseDTO.fromEntity(challenge)))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChallengeSummaryDTO> getMyChallenges(Long userId, ChallengeStatus filterStatus) {
+        List<ChallengeParticipation> participations = participationRepository.findByUser_UserId(userId);
+
+        return participations.stream()
+                .filter(p ->
+                        p.getParticipationStatus() == ParticipationStatus.IN_PROGRESS &&
+                                p.getChallengeStatus() == filterStatus
+                )
+                .map(p -> new ChallengeSummaryDTO(ChallengeBaseDTO.fromEntity(p.getChallenge())))
+                .toList();
+    }
+
+
+    @Transactional(readOnly = true)
+    public ChallengeBaseDTO getChallengeDetail(Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        return ChallengeBaseDTO.fromEntity(challenge);
+    }
+}

--- a/src/main/java/nova/backend/domain/challenge/service/OwnerChallengeService.java
+++ b/src/main/java/nova/backend/domain/challenge/service/OwnerChallengeService.java
@@ -41,14 +41,9 @@ public class OwnerChallengeService {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
 
-        ChallengeBaseDTO base = ChallengeBaseDTO.fromEntity(challenge);
-        return new OwnerChallengeDetailResponseDTO(
-                base,
-                challenge.getParticipantCount(),
-                challenge.getCompletedCount(),
-                challenge.getCanceledCount()
-        );
+        return OwnerChallengeDetailResponseDTO.fromEntity(challenge);
     }
+
 
     public List<ChallengeSummaryDTO> getUpcomingChallenges(Long cafeId) {
         LocalDate today = LocalDate.now();

--- a/src/main/java/nova/backend/domain/challenge/service/StaffChallengeService.java
+++ b/src/main/java/nova/backend/domain/challenge/service/StaffChallengeService.java
@@ -1,10 +1,10 @@
 package nova.backend.domain.challenge.service;
 
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import nova.backend.domain.challenge.dto.request.ChallengeAccumulateRequestDTO;
 import nova.backend.domain.challenge.dto.request.ChallengeCancelRequestDTO;
 import nova.backend.domain.challenge.entity.*;
+import nova.backend.domain.challenge.entity.status.ParticipationStatus;
 import nova.backend.domain.challenge.repository.ChallengeAccumulationRepository;
 import nova.backend.domain.challenge.repository.ChallengeParticipationRepository;
 import nova.backend.domain.challenge.repository.ChallengeRepository;
@@ -85,7 +85,7 @@ public class StaffChallengeService {
         List<ChallengeAccumulation> accumulations = accumulationRepository
                 .findByParticipation_ParticipationIdOrderByCreatedAtDesc(participation.getParticipationId());
 
-        int remaining = request.cancelCount();
+        int remaining = request.count();
 
         for (ChallengeAccumulation accumulation : accumulations) {
             if (remaining <= 0) break;

--- a/src/main/java/nova/backend/global/error/ErrorCode.java
+++ b/src/main/java/nova/backend/global/error/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
+
 
     /**
      * 401 Unauthorized
@@ -103,7 +105,8 @@ public enum ErrorCode {
     ALREADY_ACCUMULATED_TODAY(HttpStatus.BAD_REQUEST,"오늘은 이미 적립이 완료되었습니다."),
     CHALLENGE_ALREADY_COMPLETED_OR_CANCELED(HttpStatus.BAD_REQUEST, "카페에서 진행중인 챌린지가 아닙니다."),
     CHALLENGE_OVER_REQUEST(HttpStatus.BAD_REQUEST, "전체 적립 개수보다 더 많이 취소할 수 없습니다."),
-    CHALLENGE_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지에 참여하지 않는 고객입니다.")
+    CHALLENGE_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지에 참여하지 않는 고객입니다."),
+    INVALID_CHALLENGE_STATUS(HttpStatus.BAD_REQUEST, "챌린지가 참여 가능한 상태가 아닙니다."),
 
 
     ;

--- a/src/main/java/nova/backend/global/error/ErrorCode.java
+++ b/src/main/java/nova/backend/global/error/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "ENUM 입력값이 올바르지 않습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
 
     /**
      * 401 Unauthorized
@@ -101,7 +101,9 @@ public enum ErrorCode {
      */
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지가 존재하지 않습니다."),
     ALREADY_ACCUMULATED_TODAY(HttpStatus.BAD_REQUEST,"오늘은 이미 적립이 완료되었습니다."),
-    CHALLENGE_ALREADY_COMPLETED_OR_CANCELED(HttpStatus.BAD_REQUEST, "카페에서 진행중인 챌린지가 아닙니다.")
+    CHALLENGE_ALREADY_COMPLETED_OR_CANCELED(HttpStatus.BAD_REQUEST, "카페에서 진행중인 챌린지가 아닙니다."),
+    CHALLENGE_OVER_REQUEST(HttpStatus.BAD_REQUEST, "전체 적립 개수보다 더 많이 취소할 수 없습니다."),
+    CHALLENGE_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지에 참여하지 않는 고객입니다.")
 
 
     ;

--- a/src/main/java/nova/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/nova/backend/global/error/GlobalExceptionHandler.java
@@ -108,7 +108,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
     }
 
-
     /**
      * 위에서 정의한 Exception을 제외한 모든 예외를 handling합니다.
      */
@@ -118,4 +117,18 @@ public class GlobalExceptionHandler {
         final ErrorResponse errorBaseResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorBaseResponse);
     }
+
+    /**
+     * RequestParam 누락 시 발생하는 error를 handling합니다.
+     */
+    @ExceptionHandler(org.springframework.web.bind.MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            org.springframework.web.bind.MissingServletRequestParameterException e
+    ) {
+        log.warn(">>> handle: MissingServletRequestParameterException - {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #100 
 
## 🌱 작업 사항
스태프가 챌린지를 적립하거나 취소한다.
유저가 챌린지를 조회한다.

## 🌱 참고 사항
### Challenge 의 상태는 2가지 enum에서 관리한다.
1. ParticipationStatus -> 사용자의 의지에 따른 챌린지 상태로, 유저가 챌린지 시작을 하거나 임의로 중단할 수 있다. 
2. ChallengeStatus -> 자연스러운 챌린지 상태이다. 아직 완료되지 않거나, 성공 기준 10회에 도달했거나, 리워드 전환이 완료된 상태를 말한다. 

### 챌린지 엔티티
ChallengeAccumulation -> 챌린지에 대한 누적 기록을 뜻한다. 챌린지를 한 번 시도할 때마다 쌓이는 기록이다. 
ChallengeParticipation = ChallengeAccumulation 's', 챌린지 기록을 하나로 모아준다. 10회가 세트이다. 
Challenge -> 카페에서 관리하는 챌린지 단위이다. 이 챌린지에 유저들이 참여한다.

스탬프와 다르게 자연스러운 상태와 의지에 따른 상태가 나뉨. (챌린지는 자발적 중단 가능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 챌린지 적립 내역을 개별적으로 관리하여 여러 번 적립 및 적립 취소가 가능해졌습니다.
  - 적립 취소(카운트 단위) 기능이 추가되었습니다.
  - 챌린지 참여 철회, 진행 중/완료/보상 상태별 챌린지 조회, 상세 조회 API가 새로 도입되었습니다.

- **개선 및 변경**
  - 챌린지 적립/취소 관련 API 경로 및 요청 방식이 일부 변경되었습니다.
  - 적립 요청 시 적립 개수를 직접 지정할 수 있습니다.
  - 챌린지 상태 관리가 세분화되고, 참여 상태 및 완료 상태가 명확히 구분되었습니다.
  - 챌린지 및 참여 관련 통계 정보에 진행 중 및 보상 완료 상태가 추가되었습니다.
  - 입력값 검증 및 오류 메시지가 개선되었습니다.

- **버그 수정**
  - 필수 요청 파라미터 누락 시 적절한 오류 응답이 반환되도록 처리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->