### PR TITLE
[feat] 메인 페이지 사용자 상태 조회 기능 구현

### DIFF
--- a/src/main/java/nova/backend/domain/stamp/repository/StampRepository.java
+++ b/src/main/java/nova/backend/domain/stamp/repository/StampRepository.java
@@ -4,6 +4,7 @@ import nova.backend.domain.stamp.entity.Stamp;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
@@ -12,6 +13,6 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
     List<Stamp> findByStampBook_StampBookId(Long stampBookId);
     @EntityGraph(attributePaths = {"stampBook", "stampBook.cafe"})
     List<Stamp> findTop3ByStampBook_Cafe_CafeIdOrderByCreatedAtDesc(Long cafeId);
-
+    int countByStampBook_User_UserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/nova/backend/domain/stampBook/repository/StampBookRepository.java
+++ b/src/main/java/nova/backend/domain/stampBook/repository/StampBookRepository.java
@@ -20,5 +20,6 @@ public interface StampBookRepository extends JpaRepository<StampBook, Long> {
     List<StampBook> findByUser_UserIdAndInHomeTrueAndUsedFalse(Long userId);
     List<StampBook> findByUser_UserIdAndUsedFalse(Long userId);
     int countByUser_UserIdAndCafe_CafeIdAndRewardClaimedTrueAndUsedFalse(Long userId, Long cafeId);
+    int countByUser_UserIdAndRewardClaimedTrueAndUsedFalse(Long userId);
 
 }

--- a/src/main/java/nova/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/nova/backend/domain/user/controller/UserApi.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public interface UserApi {
 
     @Operation(
-            summary = "QR 코드 조회",
+            summary = "[메인페이지 전용] QR 코드 조회",
             description = "현재 로그인된 사용자의 프로필 QR 코드를 조회합니다. UUID로 되어있으며, 프론트에서 이를 받아서 QR 코드로 보여줘야 합니다.",
             security = @SecurityRequirement(name = "token")
     )
@@ -34,5 +34,22 @@ public interface UserApi {
     ResponseEntity<SuccessResponse<?>> getMyQrCode(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
-}
 
+    @Operation(
+            summary = "[메인페이지 전용] 사용자 상태 정보 조회",
+            description = "현재 로그인된 사용자의 이름, 오늘 적립한 스탬프 수, 아직 사용하지 않은 리워드 수를 조회합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 상태 정보 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = nova.backend.domain.user.schema.UserStatusSuccessResponse.class)
+            )
+    )
+    @GetMapping("/status")
+    ResponseEntity<SuccessResponse<?>> getUserStatus(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/nova/backend/domain/user/controller/UserController.java
+++ b/src/main/java/nova/backend/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package nova.backend.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import nova.backend.domain.user.dto.response.QrCodeResponseDTO;
+import nova.backend.domain.user.dto.response.UserStatusResponseDTO;
 import nova.backend.domain.user.service.UserService;
 import nova.backend.global.auth.CustomUserDetails;
 import nova.backend.global.common.SuccessResponse;
@@ -24,4 +25,13 @@ public class UserController implements UserApi {
         QrCodeResponseDTO qrCode = userService.getMyQrCode(userId);
         return SuccessResponse.ok(qrCode);
     }
+
+    @GetMapping("/status")
+    public ResponseEntity<SuccessResponse<?>> getUserStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        UserStatusResponseDTO response = userService.getUserStatus(userDetails.getUserId());
+        return SuccessResponse.ok(response);
+    }
+
 }

--- a/src/main/java/nova/backend/domain/user/dto/response/UserStatusResponseDTO.java
+++ b/src/main/java/nova/backend/domain/user/dto/response/UserStatusResponseDTO.java
@@ -1,0 +1,11 @@
+package nova.backend.domain.user.dto.response;
+
+public record UserStatusResponseDTO(
+        String name,
+        int todayStampCount,
+        int unusedRewardCount
+) {
+    public static UserStatusResponseDTO of(String name, int todayStampCount, int unusedRewardCount) {
+        return new UserStatusResponseDTO(name, todayStampCount, unusedRewardCount);
+    }
+}

--- a/src/main/java/nova/backend/domain/user/schema/UserStatusSuccessResponse.java
+++ b/src/main/java/nova/backend/domain/user/schema/UserStatusSuccessResponse.java
@@ -1,0 +1,8 @@
+package nova.backend.domain.user.schema;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import nova.backend.domain.user.dto.response.UserStatusResponseDTO;
+import nova.backend.global.common.SuccessResponse;
+
+@Schema(description = "사용자 상태 정보 조회 성공 응답")
+public class UserStatusSuccessResponse extends SuccessResponse<UserStatusResponseDTO> {}

--- a/src/main/java/nova/backend/domain/user/service/UserService.java
+++ b/src/main/java/nova/backend/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package nova.backend.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import nova.backend.domain.stamp.repository.StampRepository;
+import nova.backend.domain.stampBook.repository.StampBookRepository;
 import nova.backend.domain.user.dto.request.UserLoginRequestDTO;
 import nova.backend.domain.user.dto.response.QrCodeResponseDTO;
+import nova.backend.domain.user.dto.response.UserStatusResponseDTO;
 import nova.backend.domain.user.entity.Role;
 import nova.backend.domain.user.entity.SocialType;
 import nova.backend.domain.user.entity.User;
@@ -14,6 +17,7 @@ import nova.backend.global.util.QrCodeGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -22,6 +26,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final NicknameGenerator nicknameGenerator;
+    private final StampRepository stampRepository;
+    private final StampBookRepository stampBookRepository;
     private User getExistedUser(String socialId, SocialType socialType) {
         return userRepository.findBySocialTypeAndSocialId(socialType, socialId).orElse(null);
     }
@@ -56,12 +62,28 @@ public class UserService {
     }
 
     // 내 profile QR 조회
+    @Transactional(readOnly = true)
     public QrCodeResponseDTO getMyQrCode(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         return QrCodeResponseDTO.from(user.getQrCodeValue());
     }
+
+    // 메인 페이지 유저 상태 표시 (QR 진입 전)
+    @Transactional(readOnly = true)
+    public UserStatusResponseDTO getUserStatus(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        int todayStampCount = stampRepository.countByStampBook_User_UserIdAndCreatedAtBetween(
+                userId, LocalDate.now().atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay());
+
+        int unusedRewardCount = stampBookRepository.countByUser_UserIdAndRewardClaimedTrueAndUsedFalse(userId);
+
+        return UserStatusResponseDTO.of(user.getName(), todayStampCount, unusedRewardCount);
+    }
+
 
 
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #116 
 
## 🌱 작업 사항
메인페이지 상단의 사용자 상태 조회 기능을 구현한다.
(QR 진입점 바로 직전)

