### PR TITLE
[feat] S3 설정 및 Cafe Image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	//aws
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,6 @@ dependencies {
 	//spring-doc(swagger)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 
-	//aws
-	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
-
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/nova/backend/domain/cafe/dto/common/CafeBasicInfoDTO.java
+++ b/src/main/java/nova/backend/domain/cafe/dto/common/CafeBasicInfoDTO.java
@@ -13,7 +13,8 @@ public record CafeBasicInfoDTO(
         Double longitude,
         String roadAddress,
         String cafePhone,
-        CharacterType characterType
+        CharacterType characterType,
+        String cafeUrl
 
 ) {
     public static CafeBasicInfoDTO from(Cafe cafe) {
@@ -27,7 +28,8 @@ public record CafeBasicInfoDTO(
                 cafe.getLongitude(),
                 cafe.getRoadAddress(),
                 cafe.getCafePhone(),
-                cafe.getCharacterType()
+                cafe.getCharacterType(),
+                cafe.getCafeUrl()
         );
     }
 }

--- a/src/main/java/nova/backend/domain/cafe/dto/request/CafeRegistrationRequestDTO.java
+++ b/src/main/java/nova/backend/domain/cafe/dto/request/CafeRegistrationRequestDTO.java
@@ -16,7 +16,8 @@ public record CafeRegistrationRequestDTO(
         String roadAddress,
         Integer maxStampCount,
         CharacterType characterType,
-        String rewardDescription
+        String rewardDescription,
+        String cafeUrl
 ) {
     public Cafe toEntity(User owner) {
         return Cafe.builder()
@@ -30,6 +31,7 @@ public record CafeRegistrationRequestDTO(
                 .roadAddress(roadAddress)
                 .maxStampCount(maxStampCount)
                 .characterType(characterType)
+                .cafeUrl(cafeUrl)
                 .registrationStatus(CafeRegistrationStatus.REQUESTED)
                 .owner(owner)
                 .build();

--- a/src/main/java/nova/backend/domain/cafe/entity/Cafe.java
+++ b/src/main/java/nova/backend/domain/cafe/entity/Cafe.java
@@ -52,6 +52,9 @@ public class Cafe {
     @Column(nullable = false)
     private String businessNumber;
 
+    @Column
+    private String cafeUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CafeRegistrationStatus registrationStatus;

--- a/src/main/java/nova/backend/domain/cafe/schema/CafeRegistrationMultipartSchema.java
+++ b/src/main/java/nova/backend/domain/cafe/schema/CafeRegistrationMultipartSchema.java
@@ -39,6 +39,9 @@ public class CafeRegistrationMultipartSchema {
     @Schema(description = "스탬프북 디자인 JSON, 없으면 기본 스탬프북으로 저장", example = "{\"bgColor\":\"#fff\", \"stampShape\":\"circle\"}")
     public String stampBookDesignJson;
 
+    @Schema(description = "카페 대표 사진 URL", example = "https://example.com/images/cafe.jpg")
+    public String cafeUrl;
+
     @Schema(description = "사업자 등록증 PDF 파일")
     public String businessRegistrationPdf;
 }

--- a/src/main/java/nova/backend/domain/common/controller/S3Api.java
+++ b/src/main/java/nova/backend/domain/common/controller/S3Api.java
@@ -14,7 +14,7 @@ import nova.backend.domain.common.dto.PresignedUrlResponseDTO;
 import nova.backend.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "S3 API", description = "S3 파일 처리 관련 API")
+@Tag(name = "0. S3 API", description = "S3 파일 처리 관련 API")
 public interface S3Api {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/common/controller/S3Api.java
+++ b/src/main/java/nova/backend/domain/common/controller/S3Api.java
@@ -1,0 +1,67 @@
+package nova.backend.domain.common.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import nova.backend.domain.common.dto.PresignedUrlRequestDTO;
+import nova.backend.domain.common.dto.PresignedUrlResponseDTO;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "S3 API", description = "S3 파일 처리 관련 API")
+public interface S3Api {
+
+    @Operation(
+            summary = "S3 Presigned URL 생성",
+            description = "파일 업로드를 위한 presigned URL을 생성하는 API입니다.(유효 시간: 15분)  \n" +
+                    "Presigned URL 사용법 (아래 참고)  \n" +
+                    "1. ResponseBody에 directory(파일 경로)와 fileName(파일 이름)을 포함하여 <S3 Presigned URL 생성 API>를 호출합니다. \n" +
+                    "2. 응답으로 받은 presigned URL을 `그대로` 복사한 후, PUT 메서드를 사용하여 S3에 업로드할 파일을 binary 형식으로 담아서 호출합니다.  \n" +
+                    "3. 업로드된 파일은 S3 버킷에 저장되며, 해당 객체 URL을 통해 파일에 접근할 수 있습니다." +
+                    "4. DB에 s3-url 만 저장을 하기 위해서 이전에 받았던 URL에서 `?` 앞부분만 보내주세요.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PresignedUrlResponseDTO.class)
+                    )),
+    })
+    ResponseEntity<SuccessResponse<?>> generatePresignedUrl(@RequestBody PresignedUrlRequestDTO presignedUrlRequest);
+    @Operation(
+            summary = "프로필 사진 업로드용 Presigned URL 생성",
+            description = "사용자 아이디 기반으로 프로필 사진을 업로드할 수 있는 presigned URL을 생성하는 API입니다. (사용자 정보 수정 API에서 사용)  \n"+
+                    "토큰에서 추출한 UserId을 바탕으로 'profile/' 디렉토리에 프로필 이미지를 업로드할 수 있는 presigned URL을 생성합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 사진 Presigned URL 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PresignedUrlResponseDTO.class)
+                    )),
+    })
+    ResponseEntity<SuccessResponse<?>> generateCafePresignedUrl(Long userId);
+    @Operation(
+            summary = "카페 관련 사진 업로드용 Presigned URL 생성",
+            description = "사용자 아이디 기반으로 카페 사진을 업로드할 수 있는 presigned URL을 생성하는 API입니다. (사용자 정보 수정 API에서 사용)  \n"+
+                    "토큰에서 추출한 UserId을 바탕으로 'profile/' 디렉토리에 프로필 이미지를 업로드할 수 있는 presigned URL을 생성합니다.",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카페 사진 Presigned URL 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PresignedUrlResponseDTO.class)
+                    )),
+    })
+    ResponseEntity<SuccessResponse<?>> generateProfilePresignedUrl(Long userId);
+
+}

--- a/src/main/java/nova/backend/domain/common/controller/S3Controller.java
+++ b/src/main/java/nova/backend/domain/common/controller/S3Controller.java
@@ -1,0 +1,40 @@
+package nova.backend.domain.common.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import nova.backend.domain.common.dto.PresignedUrlRequestDTO;
+import nova.backend.domain.common.dto.PresignedUrlResponseDTO;
+import nova.backend.domain.common.service.S3Service;
+import nova.backend.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/s3")
+@RestController
+public class S3Controller implements S3Api{
+
+    private final S3Service s3Service;
+
+    // S3 presigned URL 생성 API
+    @PostMapping("presigned-url")
+    public ResponseEntity<SuccessResponse<?>> generatePresignedUrl(@RequestBody PresignedUrlRequestDTO presignedUrlRequest) {
+        PresignedUrlResponseDTO presignedUrl = s3Service.generatePresignedUrl(presignedUrlRequest);
+        return SuccessResponse.ok(presignedUrl);
+    }
+
+    // 카페 사진 등록용 presigned URL 생성 API
+    @PostMapping("presigned-url/cafe")
+    public ResponseEntity<SuccessResponse<?>> generateCafePresignedUrl(@AuthenticationPrincipal Long userId) {
+        PresignedUrlResponseDTO presignedUrl = s3Service.generateCafePresignedUrl(userId);
+        return SuccessResponse.ok(presignedUrl);
+    }
+
+    // 프로필 사진 업로드용 presigned URL 생성 API
+    @PostMapping("presigned-url/profile")
+    public ResponseEntity<SuccessResponse<?>> generateProfilePresignedUrl(@AuthenticationPrincipal Long userId) {
+        PresignedUrlResponseDTO presignedUrl = s3Service.generateProfilePresignedUrl(userId);
+        return SuccessResponse.ok(presignedUrl);
+    }
+}

--- a/src/main/java/nova/backend/domain/common/dto/PresignedUrlRequestDTO.java
+++ b/src/main/java/nova/backend/domain/common/dto/PresignedUrlRequestDTO.java
@@ -1,0 +1,7 @@
+package nova.backend.domain.common.dto;
+
+public record PresignedUrlRequestDTO(
+        String directory,
+        String fileName
+) {
+}

--- a/src/main/java/nova/backend/domain/common/dto/PresignedUrlResponseDTO.java
+++ b/src/main/java/nova/backend/domain/common/dto/PresignedUrlResponseDTO.java
@@ -1,0 +1,9 @@
+package nova.backend.domain.common.dto;
+
+public record PresignedUrlResponseDTO(
+        String presignedUrl
+) {
+    public static PresignedUrlResponseDTO of(String presignedUrl) {
+        return new PresignedUrlResponseDTO(presignedUrl);
+    }
+}

--- a/src/main/java/nova/backend/domain/common/service/S3Service.java
+++ b/src/main/java/nova/backend/domain/common/service/S3Service.java
@@ -1,0 +1,74 @@
+package nova.backend.domain.common.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nova.backend.domain.common.dto.PresignedUrlRequestDTO;
+import nova.backend.domain.common.dto.PresignedUrlResponseDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${s3.profile-directory}")
+    private String profileDirectory;
+
+    // 프로필 사진 업로드용 presigned url 생성
+    public PresignedUrlResponseDTO generateProfilePresignedUrl(Long userId) {
+
+        String directory = profileDirectory;
+        String fileName = "profile_user" + userId;
+
+        PresignedUrlRequestDTO presignedUrlRequest = new PresignedUrlRequestDTO(directory, fileName);
+        return generatePresignedUrl(presignedUrlRequest);
+    }
+
+    // 카페 사진 업로드용 presigned url 생성
+    public PresignedUrlResponseDTO generateCafePresignedUrl(Long userId) {
+
+        String directory = profileDirectory;
+        String fileName = "profile_cafe" + userId;
+
+        PresignedUrlRequestDTO presignedUrlRequest = new PresignedUrlRequestDTO(directory, fileName);
+        return generatePresignedUrl(presignedUrlRequest);
+    }
+
+    // presigned url 생성
+    public PresignedUrlResponseDTO generatePresignedUrl(PresignedUrlRequestDTO presignedUrlRequest) {
+        String filePath = presignedUrlRequest.directory() + "/" + presignedUrlRequest.fileName();
+        Date expiration = new Date(System.currentTimeMillis() + 1000 * 60 * 15);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, filePath)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(expiration);
+
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return PresignedUrlResponseDTO.of(url.toString());
+    }
+
+    // 파일 확장자 추출
+    private String getFileExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+    }
+
+    // 이미지 확장자 유효성 검증
+    private boolean isValidImageExtension(String extension) {
+        String normalizedExtension = extension.toLowerCase(); // 대소문자 구분 방지
+        return Arrays.asList(".jpg", ".jpeg", ".png").contains(normalizedExtension);
+    }
+}

--- a/src/main/java/nova/backend/domain/stampBook/entity/StampBook.java
+++ b/src/main/java/nova/backend/domain/stampBook/entity/StampBook.java
@@ -6,9 +6,6 @@ import nova.backend.domain.cafe.entity.Cafe;
 import nova.backend.domain.cafe.entity.CharacterType;
 import nova.backend.domain.user.entity.User;
 import nova.backend.global.common.BaseTimeEntity;
-import nova.backend.global.error.exception.BusinessException;
-
-import static nova.backend.global.error.ErrorCode.NOT_CUSTOMED;
 
 @Entity
 @Getter

--- a/src/main/java/nova/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/nova/backend/domain/user/controller/AuthApi.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "1. 인증", description = "인증 관련 API")
+@Tag(name = "0. 인증", description = "인증 관련 API")
 public interface AuthApi {
 
     @Operation(summary = "임시 토큰 발급",

--- a/src/main/java/nova/backend/domain/user/entity/User.java
+++ b/src/main/java/nova/backend/domain/user/entity/User.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import nova.backend.domain.cafe.entity.CafeStaff;
 import nova.backend.domain.stampBook.entity.StampBook;
-import nova.backend.domain.cafe.entity.Cafe;
 import nova.backend.global.common.BaseTimeEntity;
 import org.hibernate.annotations.ColumnDefault;
 

--- a/src/main/java/nova/backend/global/auth/CustomUserDetails.java
+++ b/src/main/java/nova/backend/global/auth/CustomUserDetails.java
@@ -27,9 +27,6 @@ public class CustomUserDetails implements UserDetails {
         this.selectedCafeId = selectedCafeId;
     }
 
-
-
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));

--- a/src/main/java/nova/backend/global/common/HealthCheckApiController.java
+++ b/src/main/java/nova/backend/global/common/HealthCheckApiController.java
@@ -1,7 +1,6 @@
 package nova.backend.global.common;
 
 import lombok.RequiredArgsConstructor;
-import nova.backend.global.auth.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/nova/backend/global/config/S3Config.java
+++ b/src/main/java/nova/backend/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package nova.backend.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #114 
 
## 🌱 작업 사항

- S3 presigned url 설정하기
- Spring Boot에서 S3 설정한 뒤, application.yml 업데이트
- 카페 등록 API 에 카페 사진 첨부 추가
- 카페 BaseResponseDTO에 CafeUrl 추가

## 🌱 참고 사항
테스트 완료되면 나머지 API 에도 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - S3 파일 업로드를 위한 Presigned URL 발급 API가 추가되었습니다. 일반 파일, 프로필 사진, 카페 사진 업로드용 Presigned URL을 각각 발급받을 수 있습니다.

- **버그 수정**
    - 중복된 AWS S3 SDK 의존성 선언이 제거되었습니다.

- **코드 스타일/정리**
    - 불필요한 import 및 공백이 정리되었습니다.

- **설정**
    - AWS S3 클라이언트 및 관련 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->