### PR TITLE
[refactor] 비관적 락 적용

### DIFF
--- a/src/main/java/nova/backend/domain/cafe/repository/StampBookDesignRepository.java
+++ b/src/main/java/nova/backend/domain/cafe/repository/StampBookDesignRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StampBookDesignRepository extends JpaRepository<StampBookDesign, Long> {
     boolean existsByCafe_CafeId(Long cafeId);
+
 }

--- a/src/main/java/nova/backend/domain/stamp/service/StampService.java
+++ b/src/main/java/nova/backend/domain/stamp/service/StampService.java
@@ -134,5 +134,4 @@ public class StampService {
         return StaffStampViewResponseDTO.from(targetUser, staffCafe, rewardCount, history, recentStampDtos);
     }
 
-
 }

--- a/src/main/java/nova/backend/domain/stampBook/repository/StampBookRepository.java
+++ b/src/main/java/nova/backend/domain/stampBook/repository/StampBookRepository.java
@@ -1,11 +1,16 @@
 package nova.backend.domain.stampBook.repository;
 
+import jakarta.persistence.LockModeType;
 import nova.backend.domain.stampBook.entity.StampBook;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface StampBookRepository extends JpaRepository<StampBook, Long> {
 
     List<StampBook> findByUser_UserId(Long userId);
@@ -21,5 +26,8 @@ public interface StampBookRepository extends JpaRepository<StampBook, Long> {
     List<StampBook> findByUser_UserIdAndUsedFalse(Long userId);
     int countByUser_UserIdAndCafe_CafeIdAndRewardClaimedTrueAndUsedFalse(Long userId, Long cafeId);
     int countByUser_UserIdAndRewardClaimedTrueAndUsedFalse(Long userId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sb FROM StampBook sb WHERE sb.user.userId = :userId AND sb.cafe.cafeId = :cafeId AND sb.isCompleted = false")
+    Optional<StampBook> findCurrentStampBookForUpdate(Long userId, Long cafeId);
 
 }

--- a/src/main/java/nova/backend/global/error/ErrorCode.java
+++ b/src/main/java/nova/backend/global/error/ErrorCode.java
@@ -97,6 +97,7 @@ public enum ErrorCode {
      * Stamp Error
      */
     CAFE_NOT_SELECTED(HttpStatus.BAD_REQUEST, "카페가 선택되지 않았습니다."),
+    CONCURRENT_STAMP_CREATION(HttpStatus.CONFLICT, "스탬프북 생성 시 동시성 충돌이 발생했습니다."),
 
     /**
      * Challenge Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #124 
 
## 🌱 작업 사항
curl 요청 시
```
Deadlock found when trying to get lock; try restarting transaction
```
에러 로그 확인 -> 비관적 락 적용 확인 (동시에 여러 트랜잭션이 동일 자원을 순차적으로 교차해서 점유하려다 데드락에 빠짐) 
- getOrCreateValidStampBook() 안에서 PESSMISTIC_WRITE로 락을 잡고, 그 뒤에 save()로 새스탬프북 만들어서 DB 락 충돌 발생
적절한 회피 로직 추가 
- save() 전에 한번 더 중복검사 (더블체크)
- 데드락 발생했을 때 409 conflict 반환
- 적용 확인 (2-3번 더 요청했음)
<img width="808" alt="스크린샷 2025-06-10 오전 2 15 52" src="https://github.com/user-attachments/assets/08858bcf-e465-42ef-9729-dff4568cae59" />

