### PR TITLE
[docs] swagger 문서 개선

### DIFF
--- a/src/main/java/nova/backend/domain/cafe/controller/api/CafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/api/CafeApi.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "2. 유저(USER) 카페", description = "카페 목록 관련 API")
+@Tag(name = "1. 카페(USER)", description = "카페 목록 관련 API")
 public interface CafeApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/cafe/controller/api/OwnerCafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/api/OwnerCafeApi.java
@@ -22,7 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "4. 카페(OWNER) API", description = "카페 등록/관리 API")
+@Tag(name = "3. 카페(OWNER) API", description = "카페 등록/관리 API")
 public interface OwnerCafeApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/cafe/controller/api/StaffCafeApi.java
+++ b/src/main/java/nova/backend/domain/cafe/controller/api/StaffCafeApi.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 
-@Tag(name = "3. 카페(OWNER/STAFF) 카페 선택 API", description = "로그인 후 현재 선택할 카페를 설정하는 API")
+@Tag(name = "2. 카페(STAFF) 카페 선택 API", description = "로그인 후 현재 선택할 카페를 설정하는 API")
 public interface StaffCafeApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/challenge/controller/api/ChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/api/ChallengeApi.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "2. 챌린지", description = "챌린지 관련 API")
+@Tag(name = "1. 챌린지(USER)", description = "유저 챌린지 관련 API")
 public interface ChallengeApi {
 
     @PatchMapping("/{challengeId}/withdraw")

--- a/src/main/java/nova/backend/domain/challenge/controller/api/OwnerChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/api/OwnerChallengeApi.java
@@ -17,7 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
-@Tag(name = "4. 챌린지(OWNER) API", description = "사장용 챌린지 생성 및 조회")
+@Tag(name = "3. 챌린지(OWNER) API", description = "사장용 챌린지 생성 및 조회")
 @RequestMapping("/api/owner/challenges")
 @SecurityRequirement(name = "token")
 public interface OwnerChallengeApi {

--- a/src/main/java/nova/backend/domain/challenge/controller/api/StaffChallengeApi.java
+++ b/src/main/java/nova/backend/domain/challenge/controller/api/StaffChallengeApi.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Tag(name = "3. 챌린지(STAFF) API", description = "직원/사장용 챌린지 적립 API")
+@Tag(name = "2. 챌린지(STAFF/OWNER) API", description = "직원/사장용 챌린지 적립 API")
 @RequestMapping("/api/challenges/staff")
 @SecurityRequirement(name = "token")
 public interface StaffChallengeApi {

--- a/src/main/java/nova/backend/domain/stamp/controller/api/StaffStampApi.java
+++ b/src/main/java/nova/backend/domain/stamp/controller/api/StaffStampApi.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "3. 카페(OWNER/STAFF) 스탬프", description = "스탬프 적립 및 조회 API (카페 선택 이후 사용 가능)")
+@Tag(name = "2. 스탬프(STAFF) ", description = "스탬프 적립 및 조회 API (카페 선택 이후 사용 가능)")
 public interface StaffStampApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/stamp/controller/api/StampApi.java
+++ b/src/main/java/nova/backend/domain/stamp/controller/api/StampApi.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Tag(name = "2. 유저(USER) 스탬프", description = "스탬프 조회 API")
+@Tag(name = "1. 스탬프(USER)", description = "스탬프 조회 API")
 public interface StampApi {
 
     @Operation(summary = "나의 스탬프 적립/사용 내역 조회", description = "내 스탬프 적립 및 사용 히스토리를 조회합니다. 피그마 보고 수정이 필요합니다.", security = @SecurityRequirement(name = "token"))

--- a/src/main/java/nova/backend/domain/stampBook/controller/api/StaffStampBookApi.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/api/StaffStampBookApi.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 
-@Tag(name = "3. 카페(OWNER/STAFF) 스탬프북", description = "사장/직원용 리워드 사용 API (카페 선택 후 사용 가능)")
+@Tag(name = "2. 스탬프북(STAFF)", description = "사장/직원용 리워드 사용 API (카페 선택 후 사용 가능)")
 public interface StaffStampBookApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/stampBook/controller/api/StampBookApi.java
+++ b/src/main/java/nova/backend/domain/stampBook/controller/api/StampBookApi.java
@@ -19,7 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "2. 유저(USER) 스탬프북", description = "스탬프북 관련 API, 스탬프는 단일 스탬프지만 스탬프북은 한 장을 관리합니다.")
+@Tag(name = "1. 스탬프북(USER)", description = "스탬프북 관련 API, 스탬프는 단일 스탬프지만 스탬프북은 한 장을 관리합니다.")
 public interface StampBookApi {
 
     @Operation(

--- a/src/main/java/nova/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/nova/backend/domain/user/controller/UserApi.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Tag(name = "1. 유저", description = "일반 회원 관련 API")
+@Tag(name = "1. 유저(USER)", description = "일반 회원 관련 API")
 public interface UserApi {
 
     @Operation(


### PR DESCRIPTION
## 🌱 관련 이슈
- #135 
## 🌱 작업 사항
스웨거 문서에서 권한에 따른 번호 정리



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - API 문서의 태그 이름 및 설명이 일부 변경되어, Swagger/OpenAPI 문서 내에서 카페, 챌린지, 스탬프, 스탬프북, 유저 관련 API 그룹명이 보다 명확하게 정리되었습니다.  
  - 기존 태그의 순서 및 역할 명칭이 통일되어 사용자별(유저, 사장, 직원)로 구분이 명확해졌습니다.  
  - API 기능 및 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->